### PR TITLE
Fix for error in input date (example: 15/3/1945)

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -75,7 +75,7 @@ $questionnaireresponseviewers =
 function questionnaire_check_date ($thisdate, $insert=false) {
     $dateformat = get_string('strfdate', 'questionnaire');
     if (preg_match('/(%[mdyY])(.+)(%[mdyY])(.+)(%[mdyY])/', $dateformat, $matches)) {
-        $datepieces = explode($matches[2], $thisdate);
+        $date_pieces = explode(str_replace('%','',$matches[2]), $thisdate);
         foreach ($datepieces as $datepiece) {
             if (!is_numeric($datepiece)) {
                 return 'wrongdateformat';


### PR DESCRIPTION
Entering a date in the format DD/MM/YYYY 15/3/1945 returned error.
Reviewing the code, it seems the suggested patch fixes this issue.
Please review the code change and advise if true.

Nadav :-)
