### PR TITLE
HOSSUP-2935 - Improved questionnaire_print_overview performance.

### DIFF
--- a/db/install.xml
+++ b/db/install.xml
@@ -29,6 +29,10 @@
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
         <KEY NAME="sid" TYPE="foreign" FIELDS="sid" REFTABLE="questionnaire_survey" REFFIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="course" UNIQUE="false" FIELDS="course"/>
+        <INDEX NAME="resp_view" UNIQUE="false" FIELDS="resp_view"/>
+      </INDEXES>
     </TABLE>
     <TABLE NAME="questionnaire_survey" COMMENT="questionnaire_survey table retrofitted from MySQL">
       <FIELDS>
@@ -65,6 +69,10 @@
       <KEYS>
         <KEY NAME="primary" TYPE="primary" FIELDS="id"/>
       </KEYS>
+      <INDEXES>
+        <INDEX NAME="userid" UNIQUE="false" FIELDS="userid"/>
+        <INDEX NAME="qid" UNIQUE="false" FIELDS="qid"/>
+      </INDEXES>
     </TABLE>
     <TABLE NAME="questionnaire_question" COMMENT="questionnaire_question table retrofitted from MySQL">
       <FIELDS>

--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -427,6 +427,37 @@ function xmldb_questionnaire_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2013100500, 'questionnaire');
     }
 
+    if ($oldversion < 2013100501) {
+        $table = new xmldb_table('questionnaire');
+        $index = new xmldb_index('course');
+        $index->set_attributes(XMLDB_INDEX_NOTUNIQUE, array('course'));
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        $index = new xmldb_index('resp_view');
+        $index->set_attributes(XMLDB_INDEX_NOTUNIQUE, array('resp_view'));
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        $table = new xmldb_table('questionnaire_attempts');
+        $index = new xmldb_index('userid');
+        $index->set_attributes(XMLDB_INDEX_NOTUNIQUE, array('userid'));
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        $index = new xmldb_index('qid');
+        $index->set_attributes(XMLDB_INDEX_NOTUNIQUE, array('qid'));
+        if (!$dbman->index_exists($table, $index)) {
+            $dbman->add_index($table, $index);
+        }
+
+        // Questionnaire savepoint reached.
+        upgrade_mod_savepoint(true, 2013062402, 'questionnaire');
+    }
+
     return $result;
 }
 


### PR DESCRIPTION
Hi Joseph, this patch improves the questionnaire_print_overview performance.  In testing I was seeing a serious improvement in performance from the changes. On a MariaDB command line it went from almost 10s to 0s after the changes (on a production site).  Moodle performance profiling showed me a reduction from 1070ms spent in mysql_query to 181ms on a test site.  The callgraphs showed a shift from mysql_query as the largest CPU hog to file_exists (part of the caching system).
