### PR TITLE
trim the comma separated list of email addresses

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -1503,6 +1503,7 @@ class questionnaire {
         $altbody =  "\n$body_plaintext\n";
 
         $return = true;
+        $mailaddresses = trim($mailaddresses);
         $mailaddresses = preg_split('/,|;/', $email);
         foreach ($mailaddresses as $email) {
             $userto = new Object();


### PR DESCRIPTION
As far as my testing goes:
email1@example.com, email2@example.com in the current instance the second email address will not receive an email due to the space following the comma.

Just a small issue, took me several minutes to figure out why my second recipient was not getting notifications. Thought I'd save anyone else the hassle.
