### PR TITLE
Make alerts more bootstrap compliant and message classes more specific

### DIFF
--- a/fbsections.php
+++ b/fbsections.php
@@ -252,7 +252,7 @@ foreach ($questionnaire->questions as $question) {
             $question->survey_display($formdata, $descendantsdata = '', $qnum = $n, $blankquestionnaire = true);
         }
     } else {
-        echo '<div class="notifyproblem">';
+        echo '<div class="alert alert-error">';
         echo $strcannotuse;
         echo '</div>';
         echo '<div class="qn-question">'.$question->content.'</div>';

--- a/locallib.php
+++ b/locallib.php
@@ -192,7 +192,7 @@ function questionnaire_check_date ($thisdate, $insert=false) {
 // A variant of Moodle's notify function, with a different formatting.
 function questionnaire_notify($message) {
     $message = clean_text($message);
-    $errorstart = '<div class="notifyproblem">';
+    $errorstart = '<div class="alert alert-info">';
     $errorend = '</div>';
     $output = $errorstart.$message.$errorend;
     echo $output;

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -145,19 +145,19 @@ class questionnaire {
         // Print the main part of the page.
 
         if (!$this->is_active()) {
-            echo '<div class="notifyproblem">'
+            echo '<div class="alert alert-error">'
             .get_string('notavail', 'questionnaire')
             .'</div>';
         } else if (!$this->is_open()) {
-                echo '<div class="notifyproblem">'
+                echo '<div class="alert alert-error">'
                 .get_string('notopen', 'questionnaire', userdate($this->opendate))
                 .'</div>';
         } else if ($this->is_closed()) {
-            echo '<div class="notifyproblem">'
+            echo '<div class="alert alert-error">'
             .get_string('closed', 'questionnaire', userdate($this->closedate))
             .'</div>';
         } else if (!$this->user_is_eligible($USER->id)) {
-            echo '<div class="notifyproblem">'
+            echo '<div class="alert alert-error">'
             .get_string('noteligible', 'questionnaire')
             .'</div>';
         } else if ($this->user_can_take($USER->id)) {
@@ -246,7 +246,7 @@ class questionnaire {
                     $msgstring = '';
                     break;
             }
-            echo ('<div class="notifyproblem">'.get_string("alreadyfilled", "questionnaire", $msgstring).'</div>');
+            echo ('<div class="alert alert-error">'.get_string("alreadyfilled", "questionnaire", $msgstring).'</div>');
         }
 
         // Finish the page.
@@ -659,7 +659,7 @@ class questionnaire {
             ';
         if (isset($this->questions) && $numsections) { // Sanity check.
             $this->survey_render($formdata->sec, $msg, $formdata);
-            echo '<div class="notice" style="padding: 0.5em 0 0.5em 0.2em;"><div class="buttons">';
+            echo '<div class="alert alert-warning" style="padding: 0.5em 0 0.5em 0.2em;"><div class="buttons">';
             if ($formdata->sec > 1) {
                 echo '<input type="submit" name="prev" value="<<&nbsp;'.get_string('previouspage', 'questionnaire').'" />';
             }
@@ -683,7 +683,7 @@ class questionnaire {
 
             return $msg;
         } else {
-            echo '<p>'.get_string('noneinuse', 'questionnaire').'</p>';
+            echo '<div class="alert alert-warning">'.get_string('noneinuse', 'questionnaire').'</div>';
             echo '</form>';
             echo '</div>';
         }
@@ -699,7 +699,7 @@ class questionnaire {
         $numsections = isset($this->questionsbysec) ? count($this->questionsbysec) : 0;
         if ($section > $numsections) {
             $formdata->sec = $numsections;
-            echo '<div class=warning>'.get_string('finished', 'questionnaire').'</div>';
+            echo '<div class="alert alert-error">'.get_string('finished', 'questionnaire').'</div>';
             return(false);  // Invalid section.
         }
 
@@ -839,7 +839,7 @@ class questionnaire {
         }
 
         if ($message) {
-            echo '<div class="notifyproblem">'.$message.'</div>';
+            echo '<div class="alert alert-error">'.$message.'</div>';
         }
     }
 
@@ -914,7 +914,7 @@ class questionnaire {
                     if ($numsections > 1) {
                         $pageerror = get_string('page', 'questionnaire').' '.$s.' : ';
                     }
-                    echo '<div class="notifyproblem">'.$pageerror.$errormessage.'</div>';
+                    echo '<div class="alert alert-error">'.$pageerror.$errormessage.'</div>';
                     $errors++;
                 }
                 $s ++;
@@ -931,7 +931,7 @@ class questionnaire {
                 $descendantsandchoices = questionnaire_get_descendants_and_choices($this->questions);
         }
         if ($errors == 0) {
-            echo '<div class="message">'.get_string('submitpreviewcorrect', 'questionnaire').'</div>';
+            echo '<div class="alert alert-success">'.get_string('submitpreviewcorrect', 'questionnaire').'</div>';
         }
 
         $page = 1;

--- a/questions.php
+++ b/questions.php
@@ -622,7 +622,7 @@ if ($action == "confirmdelquestion" || $action == "confirmdelquestionparent") {
     $num = get_string('position', 'questionnaire');
     $pos = $question->position.$qname;
 
-    $msg = '<div class="warning centerpara"><p>'.get_string('confirmdelquestion', 'questionnaire', $pos).'</p>';
+    $msg = '<div class="alert alert-warning centerpara"><p>'.get_string('confirmdelquestion', 'questionnaire', $pos).'</p>';
     if ($countresps !== 0) {
         $msg .= '<p>'.get_string('confirmdelquestionresps', 'questionnaire', $countresps).'</p>';
     }
@@ -637,7 +637,7 @@ if ($action == "confirmdelquestion" || $action == "confirmdelquestionparent") {
     if ($action == "confirmdelquestionparent") {
         $strnum = get_string('position', 'questionnaire');
         $qid = key($qformdata->removebutton);
-        $msg .= '<div class="warning">'.get_string('confirmdelchildren', 'questionnaire').'</div><br />';
+        $msg .= '<div class="alert alert-warning">'.get_string('confirmdelchildren', 'questionnaire').'</div><br />';
         foreach ($haschildren as $child) {
             $childname = '';
             if ($child['name']) {

--- a/questions_form.php
+++ b/questions_form.php
@@ -85,7 +85,7 @@ class questionnaire_questions_form extends moodleform {
         $mform->addGroup($addqgroup, 'addqgroup', '', ' ', false);
 
         if (isset($SESSION->questionnaire->validateresults) &&  $SESSION->questionnaire->validateresults != '') {
-            $mform->addElement('static', 'validateresult', '', '<div class="qdepend warning">'.
+            $mform->addElement('static', 'validateresult', '', '<div class="qdepend alert alert-warning">'.
                 $SESSION->questionnaire->validateresults.'</div>');
             $SESSION->questionnaire->validateresults = '';
         }

--- a/report.php
+++ b/report.php
@@ -248,7 +248,7 @@ switch ($action) {
         
         // Print the confirmation.
         echo '<p>&nbsp;</p>';
-        $msg = '<div class="warning centerpara">';
+        $msg = '<div class="alert alert-warning centerpara">';
         $msg .= get_string('confirmdelresp', 'questionnaire', $ruser.$timesubmitted);
         $msg .= '</div>';
         $urlyes = new moodle_url('report.php', array('action' => 'dvresp',
@@ -284,7 +284,7 @@ switch ($action) {
 
         // Print the confirmation.
         echo '<p>&nbsp;</p>';
-        $msg = '<div class="warning centerpara">';
+        $msg = '<div class="alert alert-warning centerpara">';
         if ($groupmode == 0) {   // No groups or visible groups.
             $msg .= get_string('confirmdelallresp', 'questionnaire');
         } else {                 // Separate groups.

--- a/styles.css
+++ b/styles.css
@@ -72,9 +72,9 @@ td.selected {
     border-bottom: 1px dashed gray;
 }
 
-#page-mod-questionnaire-complete .message,
+#page-mod-questionnaire-complete #region-main .message,
 #page-mod-questionnaire-complete .notifyproblem,
-#page-mod-questionnaire-preview .message,
+#page-mod-questionnaire-preview #region-main .message,
 #page-mod-questionnaire-preview .notifyproblem,
 #page-mod-questionnaire-complete .thankbody,
 #page-mod-questionnaire-complete .thankhead {
@@ -95,8 +95,8 @@ td.selected {
     padding: 0px;
 }
 
-#page-mod-questionnaire-complete .message,
-#page-mod-questionnaire-preview .message,
+#page-mod-questionnaire-complete #region-main .message,
+#page-mod-questionnaire-preview #region-main .message,
 #page-mod-questionnaire-complete .thankbody,
 #page-mod-questionnaire-complete .thankhead {
     border-color: blue;

--- a/view.php
+++ b/view.php
@@ -98,16 +98,16 @@ if (!$questionnaire->is_active()) {
     } else {
         $msg = 'notavail';
     }
-    echo '<div class="message">'
+    echo '<div class="alert alert-warning">'
     .get_string($msg, 'questionnaire')
     .'</div>';
 
 } else if (!$questionnaire->is_open()) {
-    echo '<div class="message">'
+    echo '<div class="alert alert-warning">'
     .get_string('notopen', 'questionnaire', userdate($questionnaire->opendate))
     .'</div>';
 } else if ($questionnaire->is_closed()) {
-    echo '<div class="message">'
+    echo '<div class="alert alert-warning">'
     .get_string('closed', 'questionnaire', userdate($questionnaire->closedate))
     .'</div>';
 } else if ($questionnaire->survey->realm == 'template') {
@@ -117,7 +117,7 @@ if (!$questionnaire->is_active()) {
     exit();
 } else if (!$questionnaire->user_is_eligible($USER->id)) {
     if ($questionnaire->questions) {
-        echo '<div class="message">'.get_string('noteligible', 'questionnaire').'</div>';
+        echo '<div class="alert alert-error">'.get_string('noteligible', 'questionnaire').'</div>';
     }
 } else if (!$questionnaire->user_can_take($USER->id)) {
     switch ($questionnaire->qtype) {
@@ -134,7 +134,7 @@ if (!$questionnaire->is_active()) {
             $msgstring = '';
             break;
     }
-    echo ('<div class="message">'.get_string("alreadyfilled", "questionnaire", $msgstring).'</div>');
+    echo ('<div class="alert alert-error">'.get_string("alreadyfilled", "questionnaire", $msgstring).'</div>');
 } else if ($questionnaire->user_can_take($USER->id)) {
     $select = 'survey_id = '.$questionnaire->survey->id.' AND username = \''.$USER->id.'\' AND complete = \'n\'';
     $resume = $DB->get_record_select('questionnaire_response', $select, null) !== false;
@@ -149,7 +149,7 @@ if (!$questionnaire->is_active()) {
     }
 }
 if ($questionnaire->is_active() && !$questionnaire->questions) {
-    echo '<p>'.get_string('noneinuse', 'questionnaire').'</p>';
+    echo '<div class="alert alert-warning">'.get_string('noneinuse', 'questionnaire').'</div>';
 }
 if ($questionnaire->is_active() && $questionnaire->capabilities->editquestions && !$questionnaire->questions) { // Sanity check.
     echo '<a href="'.$CFG->wwwroot.htmlspecialchars('/mod/questionnaire/questions.php?'.


### PR DESCRIPTION
The .message class was messing with other .message classes we had on the same page. Specific instances of .message in the CSS have been made specific to #region-main so it won't affect other instances of .message.

I also took the opportunity to change the classes to using the bootstrap alert formats as our users are expecting to see these (bootstrap is used in the clean theme and many others).
