### PR TITLE
Properly clean up deleted questions.

### DIFF
--- a/questions.php
+++ b/questions.php
@@ -126,6 +126,12 @@ if ($delq) {
             $DB->delete_records('questionnaire_response', array('survey_id' => $sid));
             $DB->delete_records('questionnaire_attempts', array('qid' => $questionnaireid));
         }
+
+        // Delete this question, but also clean up choices from other improperly deleted questions
+        $not_deleted_questions = $DB->get_fieldset_select('questionnaire_question', 'id', 'deleted = ?', array('n'));
+        list($where, $params) = $DB->get_in_or_equal($not_deleted_questions ,SQL_PARAMS_QM, 'param', false);
+        $DB->delete_records_select('questionnaire_quest_choice', 'question_id ' . $where, $params);
+        $DB->delete_records('questionnaire_question', array('deleted' => 'y'));
     }
 
     // Log question deleted event.


### PR DESCRIPTION
The questionnaire module does not completely clean up a deleted
question at the moment. It deletes some data (responses and
attempts, for example) but leaves behind the question record
(marked as deleted) and choices in the case of multichoice qns.

One Catalyst client had a course containing a questionnaire
that took 35 minutes to restore. It was discovered that this
questionnaire had multiple deleted copies of a multichoice
question listing every suburb in Australia. Adding this code
caused the deleted questions to be properly cleaned up and
was part of a series of patches that reduced the restore time
to approximately 2 minutes.

Signed-off-by: Nigel Cunningham nigelc@catalyst-au.net
