### PR TITLE
PR CONTRIB-6515 - Fixed bug with CSV export

### DIFF
--- a/classes/response/base.php
+++ b/classes/response/base.php
@@ -178,7 +178,11 @@ abstract class base {
         foreach ($extraselectfields as $field => $include) {
             $extraselect .= $extraselect === '' ? '' : ', ';
             if ($include) {
+                if ($field === 'response') {
+                    $extraselect .= $DB->sql_order_by_text($alias . '.' . $field, 1000).' AS '.$field;
+                } else {
                 $extraselect .= $alias . '.' . $field;
+                }
             } else {
                 $default = $field === 'response' ? 'null' : 0;
                 $extraselect .= $default.' AS ' . $field;

--- a/classes/response/multiple.php
+++ b/classes/response/multiple.php
@@ -147,7 +147,7 @@ class multiple extends single {
 
         $userfields = $this->user_fields_sql();
         $extraselect = '';
-        $extraselect .= 'qrm.choice_id, qro.response, 0 AS rank';
+        $extraselect .= 'qrm.choice_id, '.$DB->sql_order_by_text('qro.response', 1000).', 0 AS rank';
         $alias = 'qrm';
 
         return "

--- a/classes/response/single.php
+++ b/classes/response/single.php
@@ -187,7 +187,7 @@ class single extends base {
         global $DB;
 
         $userfields = $this->user_fields_sql();
-        $extraselect = 'qrs.choice_id, qro.response, 0 AS rank';
+        $extraselect = 'qrs.choice_id, '.$DB->sql_order_by_text('qro.response', 1000).', 0 AS rank';
         $alias = 'qrs';
 
         return "


### PR DESCRIPTION
Our databases are Oracle and we've detected this bug in some cases (with MySQL is working properly). We've tried to find a generic solution (in Oracle, converting TO_CHAR the qrX.response field is also working).

Tested in Moodle 3.1.2 Oracle databases.

This is an improving patch for the PR, which uses sql_order_by_text function instead of sql_compare_text: https://github.com/remotelearner/moodle-mod_questionnaire/pull/68

For some DB, like Oracle, it's necessary to specify "The number of chars to use for this field" (for instance 1000), because CLOB fields don't support direct returning of such fields.