### PR TITLE
Fix restoring course url in Confirmation URL field

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,5 +40,5 @@ script:
   - moodle-plugin-ci jshint
   - moodle-plugin-ci validate
   - moodle-plugin-ci phpunit
-  - moodle-plugin-ci behat
-#  - moodle-plugin-ci phpunit --coverage-text
+  - travis_wait 30 moodle-plugin-ci behat
+  - moodle-plugin-ci phpunit --coverage-text

--- a/backup/moodle2/restore_questionnaire_activity_task.class.php
+++ b/backup/moodle2/restore_questionnaire_activity_task.class.php
@@ -56,7 +56,7 @@ class restore_questionnaire_activity_task extends restore_activity_task {
 
         $contents[] = new restore_decode_content('questionnaire', array('intro'), 'questionnaire');
         $contents[] = new restore_decode_content('questionnaire_survey',
-                        array('info', 'thank_head', 'thank_body'), 'questionnaire_survey');
+                        array('info', 'thank_head', 'thank_body', 'thanks_page'), 'questionnaire_survey');
         $contents[] = new restore_decode_content('questionnaire_question', array('content'), 'questionnaire_question');
 
         return $contents;

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version  = 2016060101;  // The current module version (Date: YYYYMMDDXX)
-$plugin->requires = 2016050400; // Moodle version.
+$plugin->version  = 2017050100;  // The current module version (Date: YYYYMMDDXX)
+$plugin->requires = 2016111500; // Moodle version.
 
 $plugin->component = 'mod_questionnaire';
 
-$plugin->release  = '3.2alpha (Build - 2016052000)';
+$plugin->release  = '3.3alpha (Build - 2016111100)';
 $plugin->maturity  = MATURITY_ALPHA;


### PR DESCRIPTION
This patch fixes the Confirmation field in advanced settings on restore, so that if you have linked to a url within the course it will be correctly updated.