### PR TITLE
Fix: Reponse export fails to include all data

### DIFF
--- a/classes/response/multiple.php
+++ b/classes/response/multiple.php
@@ -137,7 +137,7 @@ class multiple extends single {
 
         $userfields = $this->user_fields_sql();
         $extraselect = '';
-        $extraselect .= 'qrm.choice_id, ' . $DB->sql_order_by_text('qro.response', 1000) . ', 0 AS rank';
+        $extraselect .= 'qrm.choice_id, ' . $DB->sql_order_by_text('qro.response', 1000) . ' AS response, 0 AS rank';
         $alias = 'qrm';
 
         return "


### PR DESCRIPTION
"Download in text format" fails to include the response data for some question types in versions 3.1.5+ on Oracle DB