### PR TITLE
Fix radar chart type missing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: php
 
 addons:
-  postgresql: "9.5"
+  postgresql: "9.6"
 
 services:
   - mysql

--- a/classes/feedback_form.php
+++ b/classes/feedback_form.php
@@ -34,7 +34,14 @@ class feedback_form extends \moodleform {
 
     public function definition() {
         global $questionnaire;
-
+        // We need to get the number of current feedbacksections to allow the radar chart type or not.
+		global $DB;
+        $sid = $questionnaire->survey->id;
+		$sql = 'SELECT COUNT(*) ' .
+           'FROM {questionnaire_fb_sections} ' .
+           'WHERE surveyid = '.$sid;
+		$numfeedbacksections = $DB->count_records_sql($sql, [$sid]);
+		
         $mform =& $this->_form;
 
         // Questionnaire Feedback Sections and Messages.
@@ -71,29 +78,18 @@ class feedback_form extends \moodleform {
                 'bipolar' => get_string('chart:bipolar', 'questionnaire'),
                 'hbar' => get_string('chart:hbar', 'questionnaire'),
                 'rose' => get_string('chart:rose', 'questionnaire')];
-            $chartgroup[] = $mform->createElement('select', 'chart_type_two_sections',
-                get_string('chart:type', 'questionnaire') . ' (' .
-                get_string('feedbackbysection', 'questionnaire') . ')', $charttypes);
-            if ($questionnaire->survey->feedbacksections > 1) {
-                $mform->setDefault('chart_type_two_sections', $questionnaire->survey->chart_type);
+            // The radar charttype is only available if there are at least 3 feedback sections.
+			if ($numfeedbacksections > 2) {
+            	$charttypes['radar'] = get_string('chart:radar', 'questionnaire');
             }
-            $mform->disabledIf('chart_type_two_sections', 'feedbacksections', 'neq', 2);
-
-            $charttypes = [null => get_string('none'),
-                'bipolar' => get_string('chart:bipolar', 'questionnaire'),
-                'hbar' => get_string('chart:hbar', 'questionnaire'),
-                'radar' => get_string('chart:radar', 'questionnaire'),
-                'rose' => get_string('chart:rose', 'questionnaire')];
             $chartgroup[] = $mform->createElement('select', 'chart_type_sections',
                 get_string('chart:type', 'questionnaire') . ' (' .
                 get_string('feedbackbysection', 'questionnaire') . ')', $charttypes);
             if ($questionnaire->survey->feedbacksections > 1) {
                 $mform->setDefault('chart_type_sections', $questionnaire->survey->chart_type);
             }
-            $mform->disabledIf('chart_type_sections', 'feedbacksections', 'eq', 0);
-            $mform->disabledIf('chart_type_sections', 'feedbacksections', 'eq', 1);
-            $mform->disabledIf('chart_type_sections', 'feedbacksections', 'eq', 2);
-
+            $mform->disabledIf('chart_type_sections', 'feedbacksections', 'neq', 2);
+            
             $mform->addGroup($chartgroup, 'chartgroup',
                 get_string('chart:type', 'questionnaire'), null, false);
             $mform->addHelpButton('chartgroup', 'chart:type', 'questionnaire');

--- a/feedback.php
+++ b/feedback.php
@@ -115,9 +115,7 @@ if ($settings = $feedbackform->get_data()) {
                 if ($settings->feedbacksections == 1) {
                     $sdata->chart_type = $settings->chart_type_global;
                 } else if ($settings->feedbacksections == 2) {
-                    $sdata->chart_type = $settings->chart_type_two_sections;
-                } else if ($settings->feedbacksections > 2) {
-                    $sdata->chart_type = $settings->chart_type_sections;
+                    $sdata->chart_type = $settings->chart_type_sections;                
                 }
             }
         } else {

--- a/report.php
+++ b/report.php
@@ -78,7 +78,7 @@ if ($outputtarget == 'pdf') {
 
 // If you can't view the questionnaire, or can't view a specified response, error out.
 $context = context_module::instance($cm->id);
-if (!$questionnaire->can_view_all_responses() && !$individualresponse) {
+if (!$questionnaire->can_view_all_responses()) {
     // Should never happen, unless called directly by a snoop...
     print_error('nopermissions', 'moodle', $CFG->wwwroot.'/mod/questionnaire/view.php?id='.$cm->id,
         get_string('viewallresponses', 'mod_questionnaire'));

--- a/report.php
+++ b/report.php
@@ -78,7 +78,7 @@ if ($outputtarget == 'pdf') {
 
 // If you can't view the questionnaire, or can't view a specified response, error out.
 $context = context_module::instance($cm->id);
-if (!$questionnaire->can_view_all_responses()) {
+if (!$questionnaire->can_view_all_responses() && !$individualresponse) {
     // Should never happen, unless called directly by a snoop...
     print_error('nopermissions', 'moodle', $CFG->wwwroot.'/mod/questionnaire/view.php?id='.$cm->id,
         get_string('viewallresponses', 'mod_questionnaire'));


### PR DESCRIPTION
Suggestion for restoring the "radar" chart type to the feedback sections (make it available when more than 2 sections). When this request is merged I will amend the documentation accordingly.