### PR TITLE
Admin default privacy settings issue 417

### DIFF
--- a/mod_form.php
+++ b/mod_form.php
@@ -60,11 +60,15 @@ class mod_questionnaire_mod_form extends moodleform_mod {
 
         $mform->addElement('hidden', 'cannotchangerespondenttype');
         $mform->setType('cannotchangerespondenttype', PARAM_INT);
-        $mform->addElement('select', 'respondenttype', get_string('respondenttype', 'questionnaire'), $questionnairerespondents);
+        $selectrespondenttype = $mform->addElement('select', 'respondenttype', get_string('respondenttype', 'questionnaire'),
+                $questionnairerespondents, array('tabindex' => 0));
+        $selectrespondenttype->setSelected(get_config('questionnaire', 'respondenttype'));
         $mform->addHelpButton('respondenttype', 'respondenttype', 'questionnaire');
         $mform->disabledIf('respondenttype', 'cannotchangerespondenttype', 'eq', 1);
 
-        $mform->addElement('select', 'resp_view', get_string('responseview', 'questionnaire'), $questionnaireresponseviewers);
+        $selectrespview = $mform->addElement('select', 'resp_view', get_string('responseview', 'questionnaire'),
+                $questionnaireresponseviewers, array('tabindex' => 0));
+        $selectrespview->setSelected(get_config('questionnaire', 'resp_view'));
         $mform->addHelpButton('resp_view', 'responseview', 'questionnaire');
 
         $notificationoptions = array(0 => get_string('no'), 1 => get_string('notificationsimple', 'questionnaire'),
@@ -143,6 +147,9 @@ class mod_questionnaire_mod_form extends moodleform_mod {
         }
 
         $this->standard_coursemodule_elements();
+
+        // Apply locked admin settings.
+        $this->apply_admin_defaults();
 
         // Buttons.
         $this->add_action_buttons();

--- a/settings.php
+++ b/settings.php
@@ -51,4 +51,26 @@ if ($ADMIN->fulltree) {
 
     $settings->add(new admin_setting_configcheckbox('questionnaire/allowemailreporting',
         get_string('configemailreporting', 'questionnaire'), get_string('configemailreportinglong', 'questionnaire'), 0));
+
+    $questionnairerespondents = array (
+            'fullname' => get_string('respondenttypefullname', 'questionnaire'),
+            'anonymous' => get_string('respondenttypeanonymous', 'questionnaire'));
+
+    $respondenttypesetting = new admin_setting_configselect('questionnaire/respondenttype',
+            get_string('default').': '.get_string('respondenttype', 'questionnaire'),
+            get_string('respondenttype_help', 'questionnaire'), 'anonymous', $questionnairerespondents);
+    $respondenttypesetting->set_locked_flag_options(admin_setting_flag::ENABLED, false);
+    $settings->add($respondenttypesetting);
+
+    $questionnaireresponseviewers = array (
+            1 => get_string('responseviewstudentswhenanswered', 'questionnaire'),
+            2 => get_string('responseviewstudentswhenclosed', 'questionnaire'),
+            3 => get_string('responseviewstudentsalways', 'questionnaire'),
+            0 => get_string('responseviewstudentsnever', 'questionnaire'));
+
+    $respviewsetting = new admin_setting_configselect('questionnaire/resp_view',
+            get_string('default').': '.get_string('responseview', 'questionnaire'),
+            get_string('responseview_help', 'questionnaire'), 0, $questionnaireresponseviewers);
+    $respviewsetting->set_locked_flag_options(admin_setting_flag::ENABLED, false);
+    $settings->add($respviewsetting);
 }


### PR DESCRIPTION
We would like to have two admin options to set default privacy settings in order to be GDPR comliant:

Respondent Type (set to "anonymous")
Students can view ALL responses (set to "never")