### PR TITLE
Questionnaire\Accessibility\Rate: table does not have a programmatically associated caption

### DIFF
--- a/classes/question/rate.php
+++ b/classes/question/rate.php
@@ -198,6 +198,7 @@ class rate extends question {
     protected function question_survey_display($response, $descendantsdata, $blankquestionnaire=false) {
         $choicetags = new \stdClass();
         $choicetags->qelements = [];
+        $choicetags->qelements['caption'] = strip_tags($this->content);
 
         $disabled = '';
         if ($blankquestionnaire) {

--- a/lang/en/questionnaire.php
+++ b/lang/en/questionnaire.php
@@ -672,3 +672,4 @@ $string['yesno_help'] = 'Simple Yes/No question.';
 $string['yourresponse'] = 'View your response(s)';
 $string['yourresponses'] = 'View your response(s)';
 $string['crontask'] = 'Questionnaire cleanup job';
+$string['nopermissions'] = 'Sorry, but you do not currently have permissions to view this page or perform this action.';

--- a/templates/question_rate.mustache
+++ b/templates/question_rate.mustache
@@ -46,6 +46,7 @@
                         }
                     ]
                 },
+                "caption": "text",
                 "rows": [
                     {
                         "cols": [
@@ -123,6 +124,7 @@
 <!-- Begin HTML generated from question_rate template. -->
 {{#qelements}}
 <table style="width:{{twidth}}">
+  <caption class="accesshide">{{caption}}</caption>
   <tbody>
     {{#qelements.headerrow}}
     <tr>

--- a/tests/behat/rate_question_na.feature
+++ b/tests/behat/rate_question_na.feature
@@ -60,3 +60,41 @@ Feature: Rate scale questions have options for displaing "N/A"
     Then I should see "Test questionnaire"
     And I should see "Rate these movies from 1 to 5"
     And I should see "N/A"
+
+  @javascript
+  Scenario: Test caption of table
+    Given the following "users" exist:
+      | username | firstname | lastname | email |
+      | teacher1 | Teacher | 1 | teacher1@example.com |
+      | student1 | Student | 1 | student1@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1 | 0 |
+    And the following "course enrolments" exist:
+      | user | course | role |
+      | teacher1 | C1 | editingteacher |
+      | student1 | C1 | student |
+    And the following "activities" exist:
+      | activity | name | description | course | idnumber |
+      | questionnaire | Test questionnaire | Test questionnaire description | C1 | questionnaire0 |
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire"
+    And I navigate to "Questions" in current page administration
+    And I add a "Rate (scale 1..5)" question and I fill the form with:
+      | Question Name | Q1 |
+      | Yes | y |
+      | Nb of scale items | 3 |
+      | Type of rate scale | No duplicate choices |
+      | Question Text | What are your top three movies? |
+      | Possible answers | Star Wars,Casablanca,Airplane,Citizen Kane,Anchorman |
+    Then I should see "position 1"
+    And I should see "[Rate (scale 1..5)] (Q1)"
+    And I should see "What are your top three movies?"
+    And I log out
+
+    And I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire"
+    And I navigate to "Answer the questions..." in current page administration
+    Then "//caption[@class='accesshide' and text()='What are your top three movies?']" "xpath_element" should exist


### PR DESCRIPTION
Hi @mchurchward 

We are from the Open University and would like to propose the change that support the accessibility screen reader for Rate question

Data tables SHOULD have a programmatically associated caption or name. Screen readers read the caption or name of the table when users navigate to the table, giving users a sense of what the table is about. The caption element is the most straightforward way to give a name to a table. The recommendation is to add an appropriate caption to the table using the <caption> tag with question text.

Could you please review this commit ?

Many thanks.