### PR TITLE
Questionnaire/Accessibility: Check boxes missing group label

### DIFF
--- a/classes/question/check.php
+++ b/classes/question/check.php
@@ -81,7 +81,7 @@ class check extends question {
      * @return \stdClass The check question context tags.
      *
      */
-    protected function question_survey_display($response, $dependants, $blankquestionnaire=false) {
+    protected function question_survey_display($response, $dependants, $blankquestionnaire = false) {
         // Check boxes.
         $otherempty = false;
         if (!empty($response)) {
@@ -148,6 +148,9 @@ class check extends question {
                     format_string(stripslashes($response->answers[$this->id][$id]->value)) : '');
                 $checkbox->label = format_text($choice->other_choice_display().'', FORMAT_HTML, ['noclean' => true]);
             }
+            if (!empty($this->qlegend)) {
+                $checkbox->alabel = strip_tags("{$this->qlegend} {$checkbox->label}");
+            }
             $choicetags->qelements[] = (object)['choice' => $checkbox];
         }
         if ($otherempty) {
@@ -191,6 +194,9 @@ class check extends question {
                 }
                 $chobj->name = $id.$uniquetag++;
                 $chobj->content = (($othertext === '') ? $id : $othertext);
+            }
+            if (!empty($this->qlegend)) {
+                $chobj->alabel = strip_tags("{$this->qlegend} {$chobj->content}");
             }
             $resptags->choices[] = $chobj;
         }

--- a/classes/question/question.php
+++ b/classes/question/question.php
@@ -94,6 +94,9 @@ abstract class question {
     /** @var string $content The question's content. */
     public $content = '';
 
+    /** @var string $qlegend The question's legend. */
+    public $qlegend = '';
+
     /** @var string $allchoices The list of all question's choices. */
     public $allchoices = '';
 
@@ -953,10 +956,12 @@ abstract class question {
         } else if ($this->type_id == QUESESSAY) {
             $pagetags->label = (object)['for' => 'q' . $this->id];
         }
+        $content = file_rewrite_pluginfile_urls($this->content, 'pluginfile.php',
+                $this->context->id, 'mod_questionnaire', 'question', $this->id);
         $options = ['noclean' => true, 'para' => false, 'filter' => true, 'context' => $this->context, 'overflowdiv' => true];
-        $content = format_text(file_rewrite_pluginfile_urls($this->content, 'pluginfile.php',
-            $this->context->id, 'mod_questionnaire', 'question', $this->id), FORMAT_HTML, $options);
-        $pagetags->qcontent = $content;
+        $pagetags->qcontent = format_text($content, FORMAT_HTML, $options);
+        $this->qlegend = strip_tags($content);
+        $pagetags->qlegend = $this->qlegend;
 
         return $pagetags;
     }

--- a/templates/question_check.mustache
+++ b/templates/question_check.mustache
@@ -55,11 +55,13 @@
     }}
 <!-- Begin HTML generated from question_check template. -->
 {{#qelements}}
-{{#choice}}
-<input id="{{choice.id}}" value="{{choice.value}}" name="{{choice.name}}" type="checkbox" {{#choice.checked}}checked="checked"{{/choice.checked}} />
-<label for="{{choice.id}}">{{{choice.label}}}</label>
-{{#choice.oname}}<input size="25" name="{{choice.oname}}" onclick="other_check(name)" value="{{choice.ovalue}}" type="text" />{{/choice.oname}}
-<br />
-{{/choice}}
+    {{#choice}}
+        <input id="{{choice.id}}" value="{{choice.value}}" name="{{choice.name}}" type="checkbox"
+               {{#choice.checked}}checked="checked"{{/choice.checked}} aria-label="{{choice.alabel}}"/>
+        <label for="{{choice.id}}">{{{choice.label}}}</label>
+        {{#choice.oname}}<input size="25" name="{{choice.oname}}" onclick="other_check(name)" value="{{choice.ovalue}}"
+                                type="text"/>{{/choice.oname}}
+        <br/>
+    {{/choice}}
 {{/qelements}}
 <!-- End HTML generated from question_check template. -->

--- a/templates/question_container.mustache
+++ b/templates/question_container.mustache
@@ -45,7 +45,7 @@
 <fieldset id="qn-{{fieldset.id}}" class="{{fieldset.class}}">
     {{{dependencylist}}}
     {{#qnum}}
-    <legend class="accesshide">{{# str }}questionnum, mod_questionnaire{{/ str}}{{{qnum}}}</legend>
+    <legend class="accesshide">{{# str }}questionnum, mod_questionnaire{{/ str}}{{{qnum}}} {{qlegend}}</legend>
     <div class="qn-legend">
         <div class="qn-info">
             <h2 class="qn-number">{{{qnum}}}</h2>

--- a/templates/response_check.mustache
+++ b/templates/response_check.mustache
@@ -48,15 +48,17 @@
 <div class="questionnaire_response questionnaire_check">{{!
 }}{{#choices}}{{!
     }}{{#selected}}{{!
-    }}<span class="selected">{{^pdf}}<input type="checkbox" name="{{name}}" checked="checked" disabled="disabled" />{{/pdf}}
-        {{{content}}}{{#pdf}} &#10003;{{/pdf}}</span>
+    }}<span class="selected">{{^pdf}}
+    <input type="checkbox" name="{{name}}" checked="checked" disabled="disabled" aria-label="{{alabel}}"/>{{/pdf}}
+    {{{content}}}{{#pdf}} &#10003;{{/pdf}}</span>
     {{#othercontent}}<span class="response text">{{{.}}}</span>{{/othercontent}}
-    {{/selected}}
+{{/selected}}
     {{^selected}}
-    <span class="unselected"{{#pdf}} color="gray"{{/pdf}}>{{^pdf}}<input type="checkbox" name="{{name}}" disabled="disabled" />{{/pdf}}
-        {{{content}}}</span>
+        <span class="unselected"{{#pdf}} color="gray"{{/pdf}}>{{^pdf}}
+            <input type="checkbox" name="{{name}}" disabled="disabled" aria-label="{{alabel}}"/>{{/pdf}}
+            {{{content}}}</span>
     {{/selected}}
-    <br />
+    <br/>
 {{/choices}}
 </div>
 <!-- End HTML generated from response_check template. -->

--- a/templates/response_container.mustache
+++ b/templates/response_container.mustache
@@ -54,9 +54,9 @@
     }}
 <!-- Begin fieldset generated from response_container template. -->
 <div class="box individualresp">
-<fieldset id="{{fieldset.id}}" class="{{fieldset.class}}">
+<fieldset id="qn-{{fieldset.id}}" class="{{fieldset.class}}">
     {{#qnum}}
-    <legend class="accesshide">{{# str }}questionnum, mod_questionnaire{{/ str}}{{{qnum}}}</legend>
+    <legend class="accesshide">{{# str }}questionnum, mod_questionnaire{{/ str}}{{{qnum}}} {{qlegend}}</legend>
     <div class="qn-legend">
         <div class="qn-info">
             <h2 class="qn-number">{{{.}}}</h2>
@@ -74,10 +74,10 @@
             {{#responses}}
             {{#respdate}}<div class="respdate">{{respdate}}</div>{{/respdate}}
             <fieldset id="{{fieldset.id}}" class="{{fieldset.class}}">
-                <legend class="accesshide">{{# str }}questionnum, mod_questionnaire{{/ str}}</legend>
+                <legend class="accesshide">{{# str }}questionnum, mod_questionnaire{{/ str}}{{{qnum}}} {{qlegend}}</legend>
                 <div class="qn-legend">
                     <div class="qn-info">
-                        <div class="accesshide">{{# str }}questionnum, mod_questionnaire{{/ str}}</div>
+                        <div class="accesshide">{{# str }}questionnum, mod_questionnaire{{/ str}}{{{qnum}}} {{qlegend}}</div>
                     </div>
                     {{{required}}}
                 </div>


### PR DESCRIPTION
Changes related to accessibility so that the checkbox answers are better-associated with the question text asked.

E.g. if the question is "Select favourite colours" and the options are Blue/Red/Green the possible responses are read out by the screen reader as:

"Select favourite colours Blue"
"Select favourite colours Red"
"Select favourite colours Green"

Additional related changes:
The question container is modified to add a new qlegend field to the legend and to make the legends consistent as some were missing the qnum field.
The response templates are also modified for consistency.
