### PR TITLE
Questionnaire: improved accessibility for essay box type

### DIFF
--- a/classes/question/question.php
+++ b/classes/question/question.php
@@ -951,7 +951,7 @@ abstract class question {
         } else if ($this->type_id == QUESDROP) {
             $pagetags->label = (object)['for' => self::qtypename($this->type_id) . $this->name];
         } else if ($this->type_id == QUESESSAY) {
-            $pagetags->label = (object)['for' => 'edit-q' . $this->id];
+            $pagetags->label = (object)['for' => 'q' . $this->id];
         }
         $options = ['noclean' => true, 'para' => false, 'filter' => true, 'context' => $this->context, 'overflowdiv' => true];
         $content = format_text(file_rewrite_pluginfile_urls($this->content, 'pluginfile.php',


### PR DESCRIPTION
Hi,
We are from The Open University,

As a user, when using the screen reader tool to access the Essay box question within the questionnaire activity, we would likely expect the screen reader to read the question.

Could you please review this change?

Many Thanks