### PR TITLE
Fix wrong param declaration in webservice

### DIFF
--- a/externallib.php
+++ b/externallib.php
@@ -137,7 +137,7 @@ class mod_questionnaire_external extends external_api {
     public static function submit_questionnaire_response_returns() {
         return new external_single_structure(
             [
-                'submitted' => new external_value(PARAM_BOOL, 'submitted', VALUE_REQUIRED, false, false),
+                'submitted' => new \external_value(PARAM_BOOL, 'submitted', VALUE_DEFAULT, false, NULL_NOT_ALLOWED),
                 'warnings' => new external_warnings()
             ]
         );


### PR DESCRIPTION
Steps to reproduce:
- Go to Server > Web services > Overview
-  Click on "Select a service" Link
- Click the add link
- Create a sample web service
- Click add function
- We will see the warning
![image](https://github.com/PoetOS/moodle-mod_questionnaire/assets/42837030/6c4f5cb5-8bce-4ead-b27c-76fed974976d)
So this change is to correct the declaration of the web service param and fix the warning message.