### PR TITLE
Have addInfo pass through filters everywhere fixes #525.

### DIFF
--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -1493,7 +1493,7 @@ class questionnaire {
             if ($this->survey->info) {
                 $infotext = file_rewrite_pluginfile_urls($this->survey->info, 'pluginfile.php',
                     $this->context->id, 'mod_questionnaire', 'info', $this->survey->id);
-                $this->page->add_to_page('addinfo', $infotext);
+                $this->page->add_to_page('addinfo', format_text($infotext, FORMAT_HTML, ['noclean' => true]));
             }
         }
 


### PR DESCRIPTION
To test:

1. Add a language pack and enable multilang filters for content and headings
2. Create a questionnaire and insert a multilanguage string in Advanced settings → Additional info
3. Go to the preview
4. **Verify** the string is given out correctly.