### PR TITLE
Allow questionnaire to be gradable LTI advantage activity

### DIFF
--- a/lib.php
+++ b/lib.php
@@ -42,7 +42,7 @@ function questionnaire_supports($feature) {
         case FEATURE_COMPLETION_HAS_RULES:
             return true;
         case FEATURE_GRADE_HAS_GRADE:
-            return false;
+            return true;
         case FEATURE_GRADE_OUTCOMES:
             return false;
         case FEATURE_GROUPINGS:
@@ -157,6 +157,9 @@ function questionnaire_add_instance($questionnaire) {
     if (!$questionnaire->id = $DB->insert_record("questionnaire", $questionnaire)) {
         return false;
     }
+
+    // Create grade line item, if initial configuration is for gradable activity
+    questionnaire_grade_item_update($questionnaire);
 
     questionnaire_set_events($questionnaire);
 

--- a/tests/lib_test.php
+++ b/tests/lib_test.php
@@ -40,7 +40,7 @@ class mod_questionnaire_lib_testcase extends advanced_testcase {
         $this->assertTrue(questionnaire_supports(FEATURE_BACKUP_MOODLE2));
         $this->assertFalse(questionnaire_supports(FEATURE_COMPLETION_TRACKS_VIEWS));
         $this->assertTrue(questionnaire_supports(FEATURE_COMPLETION_HAS_RULES));
-        $this->assertFalse(questionnaire_supports(FEATURE_GRADE_HAS_GRADE));
+        $this->assertTrue(questionnaire_supports(FEATURE_GRADE_HAS_GRADE));
         $this->assertFalse(questionnaire_supports(FEATURE_GRADE_OUTCOMES));
         $this->assertTrue(questionnaire_supports(FEATURE_GROUPINGS));
         $this->assertTrue(questionnaire_supports(FEATURE_GROUPS));


### PR DESCRIPTION
In 2013, the FEATURE_GRADE_HAS_GRADES was toggled to False without comment. This makes the questionnaire activity ineligible to send grades when using Moodle as an LTI 1.3 Tool, among other potential effects. Additionally, the grade line item isn't created when a questionnaire is initially added to a course in spite of that initial configuration allowing it to be graded; the line item is, however, added when the activity configuration is re-saved without making changes.