### PR TITLE
GHI535 Support for user identity fields in Download Responses

### DIFF
--- a/db/upgrade.php
+++ b/db/upgrade.php
@@ -997,6 +997,11 @@ function xmldb_questionnaire_upgrade($oldversion=0) {
         upgrade_mod_savepoint(true, 2022092200, 'questionnaire');
     }
 
+    if ($oldversion < 2022121600.02) {
+        // Upgrade for downloadoptions - useridentityfields setting.
+        upgrade_mod_savepoint(true, 2022121600.02, 'questionnaire');
+    }
+
     return true;
 }
 

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -3066,7 +3066,8 @@ class questionnaire {
      * @param array $questionsbyposition
      * @param int $nbinfocols
      * @param int $numrespcols
-     * @param int $showincompletes
+     * @param array $options
+     * @param array $identityfields
      * @return array
      */
     protected function process_csv_row(array &$row,
@@ -3074,20 +3075,13 @@ class questionnaire {
                                        $currentgroupid,
                                        array &$questionsbyposition,
                                        $nbinfocols,
-                                       $numrespcols, $showincompletes = 0) {
+                                       $numrespcols,
+                                       $options,
+                                       $identityfields) {
         global $DB;
 
-        static $config = null;
         // If using an anonymous response, map users to unique user numbers so that number of unique anonymous users can be seen.
         static $anonumap = [];
-
-        if ($config === null) {
-            $config = get_config('questionnaire', 'downloadoptions');
-        }
-        $options = empty($config) ? array() : explode(',', $config);
-        if ($showincompletes == 1) {
-            $options[] = 'complete';
-        }
 
         $positioned = [];
         $user = new stdClass();
@@ -3184,6 +3178,9 @@ class questionnaire {
         if (in_array('complete', $options)) {
             array_push($positioned, $resprow->complete);
         }
+        foreach ($identityfields as $field) {
+            array_push($positioned, $resprow->$field);
+        }
 
         for ($c = $nbinfocols; $c < $numrespcols; $c++) {
             if (isset($row[$c])) {
@@ -3234,10 +3231,17 @@ class questionnaire {
             if (in_array($option, array('response', 'submitted', 'id'))) {
                 $columns[] = get_string($option, 'questionnaire');
                 $types[] = 0;
+            } else if ($option == 'useridentityfields') {
+                    // Ignore option.
+                    continue;
             } else {
                 $columns[] = get_string($option);
                 $types[] = 1;
             }
+        }
+        $identityfields = $this->get_identity_fields($options);
+        foreach ($identityfields as $field) {
+            $columns[] = \core_user\fields::get_display_name($field);
         }
         $nbinfocols = count($columns);
 
@@ -3469,6 +3473,7 @@ class questionnaire {
         if ($rankaverages) {
             $averagerow = [];
         }
+        $useridentityfields = [];
         foreach ($allresponsesrs as $responserow) {
             $rid = $responserow->rid;
             $qid = $responserow->question_id;
@@ -3476,6 +3481,21 @@ class questionnaire {
             // It's possible for a response to exist for a deleted question. Ignore these.
             if (!isset($this->questions[$qid])) {
                 continue;
+            }
+
+            if (!empty($identityfields)) {
+                // Get identity fields for user.
+                if (isset($useridentityfields[$responserow->userid])) {
+                    $customfields = $useridentityfields[$responserow->userid];
+                } else {
+                    $customfields = self::get_user_identity_fields($this->context, $responserow->userid);
+                    $useridentityfields[$responserow->userid] = $customfields;
+                }
+
+                // Set profile fields for user in response row.
+                foreach ($identityfields as $field) {
+                    $responserow->{$field} = $customfields->{$field};
+                }
             }
 
             $question = $this->questions[$qid];
@@ -3494,7 +3514,7 @@ class questionnaire {
 
             if ($prevresprow !== false && $prevresprow->rid !== $rid) {
                 $output[] = $this->process_csv_row($row, $prevresprow, $currentgroupid, $questionsbyposition,
-                    $nbinfocols, $numrespcols, $showincompletes);
+                    $nbinfocols, $numrespcols, $options, $identityfields);
                 $row = [];
             }
 
@@ -3576,7 +3596,7 @@ class questionnaire {
         if ($prevresprow !== false) {
             // Add final row to output. May not exist if no response data was ever present.
             $output[] = $this->process_csv_row($row, $prevresprow, $currentgroupid, $questionsbyposition,
-                $nbinfocols, $numrespcols, $showincompletes);
+                $nbinfocols, $numrespcols, $options, $identityfields);
         }
 
         // Add averages row if appropriate.
@@ -4120,5 +4140,40 @@ class questionnaire {
         }
 
         return $areas;
+    }
+
+    /**
+     *  Gets the identity fields.
+     *
+     * @param array $options
+     * @return array
+     */
+    protected function get_identity_fields($options) {
+        $fields = !in_array('useridentityfields', $options) || $this->respondenttype == 'anonymous' ? [] :
+            \core_user\fields::get_identity_fields($this->context);
+        return $fields;
+    }
+
+    /**
+     *  Gets the identity fields values for a user.
+     *
+     * @param object $context
+     * @param int $userid
+     * @return array
+     */
+    public static function get_user_identity_fields($context, $userid) {
+        global $DB;
+
+        $fields = \core_user\fields::for_identity($context);
+        [
+            'selects' => $selects,
+            'joins' => $joins,
+            'params' => $params
+        ] = (array)$fields->get_sql('u', false, '', '', false);
+        $sql = "SELECT $selects
+                FROM {user} u $joins
+                WHERE u.id = ?";
+        $row = $DB->get_record_sql($sql, array_merge($params, [$userid]));
+        return $row;
     }
 }

--- a/settings.php
+++ b/settings.php
@@ -43,7 +43,8 @@ if ($ADMIN->fulltree) {
         'group' => get_string('group'),
         'id' => get_string('id', 'questionnaire'),
         'fullname' => get_string('fullname'),
-        'username' => get_string('username')
+        'username' => get_string('username'),
+        'useridentityfields' => get_string('showuseridentity', 'admin')
     );
 
     $settings->add(new admin_setting_configmultiselect('questionnaire/downloadoptions',

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -678,9 +678,10 @@ class mod_questionnaire_generator extends testing_module_generator {
      * @param int $studentcount
      * @param int $questionnairecount
      * @param int $questionspertype
+     * @param array $profilefields in format ['<shortname>' => '<name>']
      */
     public function create_and_fully_populate($coursecount = 4, $studentcount = 20, $questionnairecount = 2,
-                                              $questionspertype = 5) {
+                                              $questionspertype = 5, $profilefields = []) {
         global $DB;
 
         $dg = $this->datagenerator;
@@ -692,8 +693,24 @@ class mod_questionnaire_generator extends testing_module_generator {
         $courses = [];
         $questionnaires = [];
 
+        if (!empty($profilefields)) {
+            // Create profile fields and set them to show for user identity.
+            $fields = [];
+            foreach ($profilefields as $field => $name) {
+                $dg->create_custom_profile_field(['datatype' => 'text',
+                    'shortname' => $field, 'name' => $name]);
+                $fields[] = "profile_field_{$field}";
+            }
+            set_config('showuseridentity', implode(',', $fields));
+        }
+
         for ($u = 0; $u < $studentcount; $u++) {
-            $students[] = $dg->create_user(['firstname' => 'Testy']);
+            $user = ['firstname' => 'Testy'];
+            // Set values for the profile fields.
+            foreach ($profilefields as $field => $name) {
+                $user["profile_field_{$field}"] = "{$field}{$u}";
+            }
+            $students[] = $dg->create_user($user);
         }
 
         $manplugin = enrol_get_plugin('manual');

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2022121600.01;  // The current module version (Date: YYYYMMDDXX).
+$plugin->version = 2022121600.02;  // The current module version (Date: YYYYMMDDXX).
 $plugin->requires = 2022112800.00; // Moodle version (4.1.0).
 
 $plugin->component = 'mod_questionnaire';


### PR DESCRIPTION
A new option "Show user identity" in the questionnaire | downloadoptions setting to allows including/excluding the user identity fields in Download Responses.
Additionally if a questionnaire is anonymous the identity fields are excluded in a download even if "Show user identity" is on.