### PR TITLE
fix PHP8 warning due to wrong initialization format

### DIFF
--- a/classes/question/numerical.php
+++ b/classes/question/numerical.php
@@ -83,7 +83,7 @@ class numerical extends question {
         // Numeric.
         $questiontags = new \stdClass();
         $precision = $this->precise;
-        $a = '';
+        $a = new \StdClass();
         if (isset($response->answers[$this->id][0])) {
             $mynumber = $response->answers[$this->id][0]->value;
             if ($mynumber != '') {


### PR DESCRIPTION
This commit fixes the error described in the Moodle tracker [CONTRIB-9206](https://tracker.moodle.org/browse/CONTRIB-9206), and closes the issue #538