### PR TITLE
Change Default Setting for "Show All Responses to Participants" to Enhance Privacy

### DIFF
--- a/locallib.php
+++ b/locallib.php
@@ -65,10 +65,10 @@ $questionnairerealms = array ('private' => get_string('private', 'questionnaire'
 
 global $questionnaireresponseviewers;
 $questionnaireresponseviewers = array (
+            QUESTIONNAIRE_STUDENTVIEWRESPONSES_NEVER => get_string('responseviewstudentsnever', 'questionnaire'),
             QUESTIONNAIRE_STUDENTVIEWRESPONSES_WHENANSWERED => get_string('responseviewstudentswhenanswered', 'questionnaire'),
             QUESTIONNAIRE_STUDENTVIEWRESPONSES_WHENCLOSED => get_string('responseviewstudentswhenclosed', 'questionnaire'),
-            QUESTIONNAIRE_STUDENTVIEWRESPONSES_ALWAYS => get_string('responseviewstudentsalways', 'questionnaire'),
-            QUESTIONNAIRE_STUDENTVIEWRESPONSES_NEVER => get_string('responseviewstudentsnever', 'questionnaire'));
+            QUESTIONNAIRE_STUDENTVIEWRESPONSES_ALWAYS => get_string('responseviewstudentsalways', 'questionnaire'));
 
 global $autonumbering;
 $autonumbering = array (0 => get_string('autonumberno', 'questionnaire'),


### PR DESCRIPTION
Hello,

We've identified a potential privacy concern within the mod_questionnaire module, commonly used for allowing students to register for courses among other things. This involves collecting personal data from participants. Currently, when a new activity is created, the default setting for "Show all responses to participants" is set to "After completing the survey." This default setting could inadvertently lead to privacy issues, as it might allow participants to view each other's personal data if not carefully managed.

I propose we change the default setting to "Never" to prevent any potential privacy breaches and ensure a safer environment for all users. This change aims to mitigate the risk of accidental data exposure among participants.

Thank you for considering this important privacy enhancement.

Best regards,
Felix Di Lenarda