### PR TITLE
579 Fix dataformatlib.php No such file or dir

### DIFF
--- a/report.php
+++ b/report.php
@@ -485,7 +485,6 @@ switch ($action) {
 
     case 'dfs':
         require_capability('mod/questionnaire:downloadresponses', $context);
-        require_once($CFG->dirroot . '/lib/dataformatlib.php');
         // Use the questionnaire name as the file name. Clean it and change any non-filename characters to '_'.
         $name = clean_param($questionnaire->name, PARAM_FILE);
         $name = preg_replace("/[^A-Z0-9]+/i", "_", trim($name));
@@ -507,12 +506,7 @@ switch ($action) {
         // Check if email report was selected.
         $emailreport = optional_param('emailreport', '', PARAM_ALPHA);
         if (empty($emailreport)) {
-            // In 3.9 forward, download_as_dataformat is replaced by \core\dataformat::download_data.
-            if (method_exists('\\core\\dataformat', 'download_data')) {
-                \core\dataformat::download_data($name, $dataformat, $columns, $output);
-            } else {
-                download_as_dataformat($name, $dataformat, $columns, $output);
-            }
+            \core\dataformat::download_data($name, $dataformat, $columns, $output);
         } else {
             // Emailreport button selected.
             if (get_config('questionnaire', 'allowemailreporting') && (!empty($emailroles) || !empty($emailextra))) {

--- a/tests/behat/download_responses.feature
+++ b/tests/behat/download_responses.feature
@@ -1,0 +1,47 @@
+@mod @mod_questionnaire
+Feature: Questionnaire responses can be downloaded as a CSV, etc.
+
+  Background:
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | 1        | teacher1@example.com |
+      | student1 | Student   | 1        | student1@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | student1 | C1     | student        |
+    And the following "activities" exist:
+      | activity      | name                        | introduction                   | course | idnumber       |
+      | questionnaire | Test questionnaire download | Test questionnaire description | C1     | questionnaire1 |
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire download"
+    And I navigate to "Questions" in current page administration
+    And I add a "Text Box" question and I fill the form with:
+      | Question Name    | Q1              |
+      | No               | n               |
+      | Input box length | 10              |
+      | Max. text length | 15              |
+      | Question Text    | Enter some text |
+    And I log out
+    And I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire download"
+    And I navigate to "Answer the questions..." in current page administration
+    And I set the field "Enter some text" to "Student response"
+    And I press "Submit questionnaire"
+    And I log out
+
+  @javascript
+  Scenario: Download responses
+    Given I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire download"
+    And I navigate to "View all responses" in current page administration
+    Then I click on "Download" "link"
+    # Without the ability to check the downloaded file, the absence of an
+    # exception being thrown here is considered a success.
+    And I click on "Download" "button"


### PR DESCRIPTION
Remove require_once() for a core file removed in Moodle 4.4 (MDL-80409). This plugin requires Moodle 4.1 and so instead can use the replacement introduced in Moodle 3.9, dataformat::download_data().

Proposed fix for #579 