### PR TITLE
594 Fix formChild is null

### DIFF
--- a/classes/output/renderer.php
+++ b/classes/output/renderer.php
@@ -147,6 +147,7 @@ class renderer extends \plugin_renderer_base {
         foreach ($hiddeninputs as $name => $value) {
             $output .= \html_writer::empty_tag('input', ['type' => 'hidden', 'name' => $name, 'value' => $value]) . "\n";
         }
+        $this->page->requires->js_init_call('M.mod_questionnaire.init_attempt_form', null, false, questionnaire_get_js_module());
         return $output;
     }
 

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -270,10 +270,6 @@ class questionnaire {
 
         $PAGE->set_title(format_string($this->name));
         $PAGE->set_heading(format_string($this->course->fullname));
-
-        // Initialise the JavaScript.
-        $PAGE->requires->js_init_call('M.mod_questionnaire.init_attempt_form', null, false, questionnaire_get_js_module());
-
         $message = $this->user_access_messages($USER->id, true);
         if ($message !== false) {
             $this->page->add_to_page('notifications', $message);


### PR DESCRIPTION
When a student completed a questionnaire then shown the "Thank you for completing this Questionnaire" page there was a JavaScript error:

  Uncaught TypeError: formChild is null

This was because the JavaScript for the questions form was being inadvertently loaded for the Thank you page where this form is not present.