### PR TITLE
Fix the Behat tests using deprecated activity add cmd, resolves #585

### DIFF
--- a/tests/behat/public_questionnaire.feature
+++ b/tests/behat/public_questionnaire.feature
@@ -39,14 +39,14 @@ Feature: Questionnaires can use an existing public survey to gather responses in
       | Question Text | Enter a number |
 
     And I am on "Course 2" course homepage with editing mode on
-    And I add a "Questionnaire" to section "1" and I fill the form with:
+    And I add a questionnaire activity to course "Course 2" section "1" and I fill the form with:
       | Name | Questionnaire instance 1 |
       | Description | Description |
       | Use public | Public questionnaire [Course 1] |
     Then I should see "Questionnaire instance 1"
 
     And I am on "Course 3" course homepage with editing mode on
-    And I add a "Questionnaire" to section "1" and I fill the form with:
+    And I add a questionnaire activity to course "Course 3" section "1" and I fill the form with:
       | Name | Questionnaire instance 2 |
       | Description | Description |
       | Use public | Public questionnaire [Course 1] |

--- a/tests/behat/public_questionnaire_teacher.feature
+++ b/tests/behat/public_questionnaire_teacher.feature
@@ -42,7 +42,7 @@ Feature: Public questionnaires gather all instance responses in one master cours
 
     And I log in as "teacher2"
     And I am on "Course 2" course homepage with editing mode on
-    And I add a "Questionnaire" to section "1" and I fill the form with:
+    And I add a questionnaire activity to course "Course 2" section "1" and I fill the form with:
       | Name | Questionnaire instance 1 |
       | Description | Description |
       | Use public | Public questionnaire [Course 1] |
@@ -51,7 +51,7 @@ Feature: Public questionnaires gather all instance responses in one master cours
 
     And I log in as "teacher3"
     And I am on "Course 3" course homepage with editing mode on
-    And I add a "Questionnaire" to section "1" and I fill the form with:
+    And I add a questionnaire activity to course "Course 3" section "1" and I fill the form with:
       | Name | Questionnaire instance 2 |
       | Description | Description |
       | Use public | Public questionnaire [Course 1] |

--- a/tests/behat/view_questionnaire.feature
+++ b/tests/behat/view_questionnaire.feature
@@ -71,14 +71,14 @@ Feature: Questionnaires can be public, private or template
     And I press "Save and return to course"
 # Verify that a public questionnaire cannot be used in the same course.
     And I am on "Course 1" course homepage with editing mode on
-    And I add a "Questionnaire" to section "1"
+    And I add a questionnaire activity to course "Course 1" section "1"
     And I expand all fieldsets
     Then I should see "(No public questionnaires.)"
     And I press "Cancel"
 # Verify that a public questionnaire can be used in a different course.
     And I am on site homepage
     And I am on "Course 2" course homepage
-    And I add a "Questionnaire" to section "1"
+    And I add a questionnaire activity to course "Course 2" section "1"
     And I expand all fieldsets
     And I set the field "name" to "Questionnaire from public"
     And I click on "Test questionnaire [Course 1]" "radio"


### PR DESCRIPTION
This lets your Behat tests turn green, including for Moodle 4.4.
Note that you can omit phpcpd in the Moodle Plugin CI configuration, it is no longer used and will be deprecated.