### PR TITLE
Add free text (Other) to rate/scale.

### DIFF
--- a/classes/question/rate.php
+++ b/classes/question/rate.php
@@ -336,8 +336,22 @@ class rate extends question {
                 if ($this->osgood_rate_scale()) {
                     list($content, $contentright) = array_merge(preg_split('/[|]/', $content), array(' '));
                 }
-                $cols[] = ['colstyle' => 'text-align: '.$textalign.';',
-                           'coltext' => format_text($content, FORMAT_HTML, ['noclean' => true]).'&nbsp;'];
+                if ($choice->is_other_choice()) {
+                    $othertext = $choice->other_choice_display();
+                    $oname = $cid . '_qother';
+                    $oid = $cid . '-other';
+                    $odata = isset($response->answers[$this->id][$cid]) ? $response->answers[$this->id][$cid]->value : '';
+                    if (isset($odata)) {
+                        $ovalue = stripslashes($odata);
+                    }
+                    $content = $othertext;
+                    $cols[] = ['oname' => $oname, 'oid' => $oid, 'ovalue' => $ovalue,
+                            'colstyle' => 'text-align: ' . $textalign . ';',
+                            'coltext' => format_text($content, FORMAT_HTML, ['noclean' => true]) . '&nbsp;'];
+                } else {
+                    $cols[] = ['colstyle' => 'text-align: '.$textalign.';',
+                            'coltext' => format_text($content, FORMAT_HTML, ['noclean' => true]) . '&nbsp;'];
+                }
 
                 $bg = 'c0 raterow';
                 $hasnotansweredchoice = false;
@@ -511,6 +525,12 @@ class rate extends question {
                 }
                 if ($this->osgood_rate_scale()) {
                     list($content, $contentright) = array_merge(preg_split('/[|]/', $content), array(' '));
+                }
+                if ($choice->is_other_choice()) {
+                    $content = $choice->other_choice_display();
+                    if (isset($response->answers[$this->id][$cid]->otheresponse)) {
+                        $rowobj->othercontent = $response->answers[$this->id][$cid]->otheresponse;
+                    }
                 }
                 $rowobj->content = format_text($content, FORMAT_HTML, ['noclean' => true]).'&nbsp;';
                 $bg = 'c0';

--- a/classes/responsetype/answer/answer.php
+++ b/classes/responsetype/answer/answer.php
@@ -43,20 +43,25 @@ class answer {
     /** @var string $value The value of this response (if applicable). */
     public $value;
 
+    /** @var string $value The other value of this response (if applicable). */
+    public $otheresponse;
+
     /**
      * Answer constructor.
      * @param null $id
      * @param null $responseid
      * @param null $questionid
      * @param null $choiceid
+     * @param null $otheresponse
      * @param null $value
      */
-    public function __construct($id = null, $responseid = null, $questionid = null, $choiceid = null, $value = null) {
+    public function __construct($id = null, $responseid = null, $questionid = null, $choiceid = null, $value = null, $otheresponse = null) {
         $this->id = $id;
         $this->responseid = $responseid;
         $this->questionid = $questionid;
         $this->choiceid = $choiceid;
         $this->value = $value;
+        $this->otheresponse = $otheresponse;
     }
 
     /**
@@ -78,6 +83,6 @@ class answer {
         }
 
         return new answer($answerdata['id'], $answerdata['responseid'], $answerdata['questionid'], $answerdata['choiceid'],
-            $answerdata['value']);
+                $answerdata['value'], $answerdata['otheresponse']);
     }
 }

--- a/classes/responsetype/rank.php
+++ b/classes/responsetype/rank.php
@@ -156,18 +156,29 @@ class rank extends responsetype {
         global $DB;
 
         $rsql = '';
+        $params = [];
         if (!empty($rids)) {
             list($rsql, $params) = $DB->get_in_or_equal($rids);
             $rsql = ' AND response_id ' . $rsql;
         }
+        // Get other choices.
+        $otherrecs = $this->get_other_choice($rsql, $params);
 
         $select = 'question_id=' . $this->question->id . ' ORDER BY id ASC';
         if ($rows = $DB->get_records_select('questionnaire_quest_choice', $select)) {
             foreach ($rows as $row) {
-                $this->counts[$row->content] = new \stdClass();
                 $nbna = $DB->count_records(static::response_table(), array('question_id' => $this->question->id,
-                                'choice_id' => $row->id, 'rankvalue' => '-1'));
-                $this->counts[$row->content]->nbna = $nbna;
+                        'choice_id' => $row->id, 'rankvalue' => '-1'));
+                if (\mod_questionnaire\question\choice::content_is_other_choice($row->content) && !empty($otherrecs)) {
+                    foreach (array_keys($otherrecs) as $key) {
+                        $this->counts[$key] = new \stdClass();
+                        $this->counts[$key]->nbna = $nbna;
+                        $this->counts[$key]->content = $row->content;
+                    }
+                } else {
+                    $this->counts[$row->content] = new \stdClass();
+                    $this->counts[$row->content]->nbna = $nbna; 
+                }
             }
         }
 
@@ -201,51 +212,68 @@ class rank extends responsetype {
             }
 
             $sql = "SELECT c.id, c.content, a.average, a.num
-                    FROM {questionnaire_quest_choice} c
-                    INNER JOIN
+                      FROM {questionnaire_quest_choice} c
+                INNER JOIN
                          (SELECT c2.id, AVG(a2.rankvalue) AS average, COUNT(a2.response_id) AS num
-                          FROM {questionnaire_quest_choice} c2, {".static::response_table()."} a2
-                          WHERE c2.question_id = ? AND a2.question_id = ? AND a2.choice_id = c2.id AND a2.rankvalue >= 0{$rsql}
-                          GROUP BY c2.id) a ON a.id = c.id
-                          order by c.id";
+                            FROM {questionnaire_quest_choice} c2, {".static::response_table()."} a2
+                           WHERE c2.question_id = ? AND a2.question_id = ? AND a2.choice_id = c2.id 
+                                 AND a2.rankvalue >= 0 AND c2.content NOT LIKE '!other%'{$rsql}
+                        GROUP BY c2.id) a ON a.id = c.id
+                  ORDER BY c.id";
             $results = $DB->get_records_sql($sql, array_merge(array($this->question->id, $this->question->id), $params));
-            if (!empty($results)) {
-                $choiceids = array_keys($results);
-                $otherresultcontent = self::get_other_choice($choiceids);
-                if (!empty ($rankvalue)) {
-                    foreach ($results as $key => $result) {
-                        if (isset($value[$key])) {
-                            $result->averagevalue = $value[$key] / $result->num;
-                        }
+
+            // Handle 'other...'.
+            if ($otherrecs) {
+                $i = 1;
+                foreach ($otherrecs as $rec) {
+                    $results['other'.$i] = new \stdClass();
+                    $results['other'.$i]->id = $rec->cid;
+                    $results['other'.$i]->content = $rec->response;
+                    $results['other'.$i]->average = $rec->average;
+                    $results['other'.$i]->num = $rec->num;
+                    $results['other'.$i]->isother = true;
+                    $i++;
+                }
+            }
+
+            if (!empty ($rankvalue)) {
+                foreach ($results as $key => $result) {
+                    if (isset($value[$key])) {
+                        $result->averagevalue = $value[$key] / $result->num;
                     }
                 }
             }
             // Reindex by 'content'. Can't do this from the query as it won't work with MS-SQL.
             foreach ($results as $key => $result) {
                 $results[$result->content] = $result;
-                if ($result->id) {
-                    if (isset($otherresultcontent[$result->id])) {
-                        $results[$result->content]->content = $otherresultcontent[$result->id];
-                    }
-                }
                 unset($results[$key]);
             }
             return $results;
             // Case where scaleitems is less than possible choices.
         } else {
             $sql = "SELECT c.id, c.content, a.sum, a.num
-                    FROM {questionnaire_quest_choice} c
-                    INNER JOIN
+                      FROM {questionnaire_quest_choice} c
+                INNER JOIN
                          (SELECT c2.id, SUM(a2.rankvalue) AS sum, COUNT(a2.response_id) AS num
-                          FROM {questionnaire_quest_choice} c2, {".static::response_table()."} a2
-                          WHERE c2.question_id = ? AND a2.question_id = ? AND a2.choice_id = c2.id AND a2.rankvalue >= 0{$rsql}
-                          GROUP BY c2.id) a ON a.id = c.id";
-            $results = $DB->get_records_sql($sql, array_merge(array($this->question->id, $this->question->id), $params));
-            if (!empty($results)) {
-                $choiceids = array_keys($results);
-                $otherresultcontent = self::get_other_choice($choiceids);
-            }
+                            FROM {questionnaire_quest_choice} c2, {".static::response_table()."} a2
+                           WHERE c2.question_id = ? AND a2.question_id = ? AND a2.choice_id = c2.id 
+                                 AND a2.rankvalue >= 0 AND c2.content NOT LIKE '!other%'{$rsql}
+                  GROUP BY c2.id) a ON a.id = c.id";
 
+            $results = $DB->get_records_sql($sql, array_merge(array($this->question->id, $this->question->id), $params));
+
+            if ($otherrecs) {
+                $i = 1;
+                foreach ($otherrecs as $rec) {
+                    $results['other'.$i] = new \stdClass();
+                    $results['other'.$i]->id = $rec->cid;
+                    $results['other'.$i]->content = $rec->response;
+                    $results['other'.$i]->sum = $rec->average;
+                    $results['other'.$i]->num = $rec->num;
+                    $results['other'.$i]->isother = true;
+                    $i++;
+                }
+            }
             // Formula to calculate the best ranking order.
             $nbresponses = count($rids);
             foreach ($results as $key => $result) {
@@ -255,9 +283,6 @@ class rank extends responsetype {
                     $result->average = ($result->sum + ($nbresponses - $result->num) * 1 ) / $nbresponses;
                 }
                 $results[$result->content] = $result;
-                if (isset($otherresultcontent[$result->id])) {
-                    $results[$result->content]->content = $otherresultcontent[$result->id];
-                }
                 unset($results[$key]);
             }
             return $results;
@@ -265,37 +290,28 @@ class rank extends responsetype {
     }
 
     /**
-     * @param $choiceids
+     * Get a list of other available choices.
+     *
+     * @param string $rsql
+     * @param array $params
      * @return array
      */
-    public function get_other_choice($choiceids) {
+    public function get_other_choice(string $rsql, array $params): array {
         global $DB;
-        list($othersql, $params) = $DB->get_in_or_equal($choiceids);
-        $osql = "SELECT ro.*,rr.rankvalue FROM {questionnaire_response_other} ro
-             INNER JOIN {".static::response_table()."} rr ON ro.choice_id = rr.choice_id 
-                        AND ro.question_id = rr.question_id AND rr.response_id = ro.response_id
-                  WHERE ro.choice_id $othersql
-                     ";
-        $otheresults = $DB->get_records_sql($osql, $params);
-        $otherresultcontent = [];
-        if (!empty($otheresults)) {
-            foreach ($otheresults as $key => $oresult) {
-                if (array_key_last($otheresults) == $key) {
-                    if (isset($otherresultcontent[$oresult->choice_id])) {
-                        $otherresultcontent[$oresult->choice_id] .=  $oresult->response . '(' . $oresult->rankvalue . ')';
-                    } else {
-                        $otherresultcontent[$oresult->choice_id] = $oresult->response . '(' . $oresult->rankvalue . ')';
-                    }
-                } else {
-                    if (isset($otherresultcontent[$oresult->choice_id])) {
-                        $otherresultcontent[$oresult->choice_id] .=  $oresult->response . '(' . $oresult->rankvalue . '), ';
-                    } else {
-                        $otherresultcontent[$oresult->choice_id] = $oresult->response . '(' . $oresult->rankvalue . '), ';
-                    }
-                }
-            }
-        }
-        return $otherresultcontent;
+        $osql = "SELECT ro.response, AVG(a.rankvalue) AS average, COUNT(a.response_id) AS num, c.id as cid
+                   FROM {questionnaire_quest_choice} c
+             INNER JOIN {" . static::response_table() . "} a ON a.choice_id = c.id
+                        AND a.rankvalue >= 0
+                        AND a.question_id = c.question_id{$rsql}
+             INNER JOIN {questionnaire_response_other} ro  ON ro.choice_id = c.id
+                        AND ro.response_id = a.response_id
+                        AND ro.question_id = c.question_id
+                  WHERE c.question_id = ?
+                        AND c.content = '!other'
+                        AND ro.response <> ''
+               GROUP BY ro.response, cid
+               ORDER BY cid";
+        return $DB->get_records_sql($osql, array_merge($params, [$this->question->id]));
     }
 
     /**
@@ -708,8 +724,10 @@ class rank extends responsetype {
                             $content = $contents->text;
                         }
                     }
-                    if (\mod_questionnaire\question\choice::content_other_choice_display($content)) {
-                        $content = \mod_questionnaire\question\choice::content_other_choice_display($content);
+                    if (isset($contentobj->content) &&
+                            \mod_questionnaire\question\choice::content_other_choice_display($contentobj->content)) {
+                        $othertext = \mod_questionnaire\question\choice::content_other_choice_display($contentobj->content);
+                        $content = $othertext . ' ' . clean_text($content);
                     }
                     if ($osgood) {
                         $choicecol1 = new \stdClass();
@@ -835,15 +853,21 @@ class rank extends responsetype {
             $rsql = ' AND response_id ' . $rsql;
         }
 
-        array_unshift($params, $this->question->id); // This is question_id.
-        $sql = 'SELECT r.id, c.content, r.rankvalue, c.id AS choiceid ' .
-            'FROM {questionnaire_quest_choice} c , ' .
-            '{questionnaire_response_rank} r ' .
-            'WHERE c.question_id = ?' .
-            ' AND r.question_id = c.question_id' .
-            ' AND r.choice_id = c.id ' .
-            $rsql .
-            ' ORDER BY choiceid, rankvalue ASC';
+        // This is question_id.
+        array_push($params, $this->question->id);
+        $sql = "SELECT r.id,
+                       CASE 
+                            WHEN c.content = '!other' THEN o.response 
+                            ELSE c.content
+                       END as content, r.rankvalue, c.id AS choiceid
+                  FROM {questionnaire_quest_choice} c
+            INNER JOIN {" . static::response_table() . "} r ON r.question_id = c.question_id
+                       AND r.choice_id = c.id{$rsql}
+             LEFT JOIN {questionnaire_response_other} o ON o.choice_id = c.id
+                       AND o.response_id = r.response_id
+                       AND o.question_id = c.question_id
+                 WHERE c.question_id = ? AND (c.content != '!other' OR (o.response IS NOT NULL AND o.response <> ''))
+              ORDER BY choiceid, rankvalue ASC";
         $choices = $DB->get_records_sql($sql, $params);
 
         // Sort rows (results) by average value.
@@ -873,10 +897,10 @@ class rank extends responsetype {
         if (!empty($this->question->nameddegrees)) {
             $rankvalue = array_flip(array_keys($this->question->nameddegrees));
         }
-        foreach ($rows as $row) {
+        foreach ($rows as $key => $row) {
             $choiceid = $row->id;
             foreach ($choices as $choice) {
-                if ($choice->choiceid == $choiceid) {
+                if ($choice->choiceid == $choiceid && $choice->content === $key) {
                     $n = 0;
                     for ($i = 1; $i <= $nbranks; $i++) {
                         if ((isset($rankvalue[$choice->rankvalue]) && ($rankvalue[$choice->rankvalue] == ($i - 1))) ||
@@ -967,9 +991,8 @@ class rank extends responsetype {
                     // Ensure there are two bits of content.
                     list($content, $contentright) = array_merge(preg_split('/[|]/', $content), array(' '));
                     $header = reset($pagetags->totals->headers);
-                    $responsetxt = \mod_questionnaire\question\choice::content_other_choice_display($content);
-                    if (isset($rows[$content]) && $responsetxt) {
-                        $content = $responsetxt . $rows[$content]->content;
+                    if (isset($rows[$content]) && isset($rows[$content]->isother) && $rows[$content]->isother) {
+                        $content = get_string('other', 'questionnaire') . ' ' . $content;
                     }
                     $totalcols[] = (object)['align' => $header->align,
                         'text' => format_text($content, FORMAT_HTML, ['noclean' => true, 'filter' => false])];
@@ -979,9 +1002,8 @@ class rank extends responsetype {
                     if ($contents->modname) {
                         $content = $contents->text;
                     }
-                    $responsetxt = \mod_questionnaire\question\choice::content_other_choice_display($content);
-                    if (isset($rows[$content]) && $responsetxt) {
-                        $content = $responsetxt . $rows[$content]->content;
+                    if (isset($rows[$content]) && isset($rows[$content]->isother) && $rows[$content]->isother) {
+                        $content = get_string('other', 'questionnaire') . ' ' . $content;
                     }
                     $header = reset($pagetags->totals->headers);
                     $totalcols[] = (object)['align' => $header->align,

--- a/classes/responsetype/rank.php
+++ b/classes/responsetype/rank.php
@@ -132,6 +132,14 @@ class rank extends responsetype {
                 $record->choice_id = $answer->choiceid;
                 $record->rankvalue = $answer->value;
                 $resid = $DB->insert_record(static::response_table(), $record);
+                if (isset($responsedata->{$answer->choiceid . '_qother'})) {
+                    $otherrecord = new \stdClass();
+                    $otherrecord->response_id = $response->id;
+                    $otherrecord->question_id = $this->question->id;
+                    $otherrecord->choice_id = $answer->choiceid;
+                    $otherrecord->response = $responsedata->{$answer->choiceid . '_qother'};
+                    $DB->insert_record('questionnaire_response_other', $otherrecord);
+                }
             }
         }
         return $resid;
@@ -153,7 +161,7 @@ class rank extends responsetype {
             $rsql = ' AND response_id ' . $rsql;
         }
 
-        $select = 'question_id=' . $this->question->id . ' AND content NOT LIKE \'!other%\' ORDER BY id ASC';
+        $select = 'question_id=' . $this->question->id . ' ORDER BY id ASC';
         if ($rows = $DB->get_records_select('questionnaire_quest_choice', $select)) {
             foreach ($rows as $row) {
                 $this->counts[$row->content] = new \stdClass();
@@ -201,16 +209,25 @@ class rank extends responsetype {
                           GROUP BY c2.id) a ON a.id = c.id
                           order by c.id";
             $results = $DB->get_records_sql($sql, array_merge(array($this->question->id, $this->question->id), $params));
-            if (!empty ($rankvalue)) {
-                foreach ($results as $key => $result) {
-                    if (isset($value[$key])) {
-                        $result->averagevalue = $value[$key] / $result->num;
+            if (!empty($results)) {
+                $choiceids = array_keys($results);
+                $otherresultcontent = self::get_other_choice($choiceids);
+                if (!empty ($rankvalue)) {
+                    foreach ($results as $key => $result) {
+                        if (isset($value[$key])) {
+                            $result->averagevalue = $value[$key] / $result->num;
+                        }
                     }
                 }
             }
             // Reindex by 'content'. Can't do this from the query as it won't work with MS-SQL.
             foreach ($results as $key => $result) {
                 $results[$result->content] = $result;
+                if ($result->id) {
+                    if (isset($otherresultcontent[$result->id])) {
+                        $results[$result->content]->content = $otherresultcontent[$result->id];
+                    }
+                }
                 unset($results[$key]);
             }
             return $results;
@@ -224,15 +241,61 @@ class rank extends responsetype {
                           WHERE c2.question_id = ? AND a2.question_id = ? AND a2.choice_id = c2.id AND a2.rankvalue >= 0{$rsql}
                           GROUP BY c2.id) a ON a.id = c.id";
             $results = $DB->get_records_sql($sql, array_merge(array($this->question->id, $this->question->id), $params));
+            if (!empty($results)) {
+                $choiceids = array_keys($results);
+                $otherresultcontent = self::get_other_choice($choiceids);
+            }
+
             // Formula to calculate the best ranking order.
             $nbresponses = count($rids);
             foreach ($results as $key => $result) {
-                $result->average = ($result->sum + ($nbresponses - $result->num) * ($this->length + 1)) / $nbresponses;
+                if (isset($this->length)) {
+                    $result->average = ($result->sum + ($nbresponses - $result->num) * ($this->length + 1)) / $nbresponses;
+                } else {
+                    $result->average = ($result->sum + ($nbresponses - $result->num) * 1 ) / $nbresponses;
+                }
                 $results[$result->content] = $result;
+                if (isset($otherresultcontent[$result->id])) {
+                    $results[$result->content]->content = $otherresultcontent[$result->id];
+                }
                 unset($results[$key]);
             }
             return $results;
         }
+    }
+
+    /**
+     * @param $choiceids
+     * @return array
+     */
+    public function get_other_choice($choiceids) {
+        global $DB;
+        list($othersql, $params) = $DB->get_in_or_equal($choiceids);
+        $osql = "SELECT ro.*,rr.rankvalue FROM {questionnaire_response_other} ro
+             INNER JOIN {".static::response_table()."} rr ON ro.choice_id = rr.choice_id 
+                        AND ro.question_id = rr.question_id AND rr.response_id = ro.response_id
+                  WHERE ro.choice_id $othersql
+                     ";
+        $otheresults = $DB->get_records_sql($osql, $params);
+        $otherresultcontent = [];
+        if (!empty($otheresults)) {
+            foreach ($otheresults as $key => $oresult) {
+                if (array_key_last($otheresults) == $key) {
+                    if (isset($otherresultcontent[$oresult->choice_id])) {
+                        $otherresultcontent[$oresult->choice_id] .=  $oresult->response . '(' . $oresult->rankvalue . ')';
+                    } else {
+                        $otherresultcontent[$oresult->choice_id] = $oresult->response . '(' . $oresult->rankvalue . ')';
+                    }
+                } else {
+                    if (isset($otherresultcontent[$oresult->choice_id])) {
+                        $otherresultcontent[$oresult->choice_id] .=  $oresult->response . '(' . $oresult->rankvalue . '), ';
+                    } else {
+                        $otherresultcontent[$oresult->choice_id] = $oresult->response . '(' . $oresult->rankvalue . '), ';
+                    }
+                }
+            }
+        }
+        return $otherresultcontent;
     }
 
     /**
@@ -417,9 +480,17 @@ class rank extends responsetype {
         global $DB;
 
         $answers = [];
-        $sql = 'SELECT id, response_id as responseid, question_id as questionid, choice_id as choiceid, rankvalue as value ' .
-            'FROM {' . static::response_table() .'} ' .
-            'WHERE response_id = ? ';
+        $sql = 'SELECT r.id, 
+                       r.response_id AS responseid, 
+                       r.question_id AS questionid, 
+                       r.choice_id AS choiceid, 
+                       r.rankvalue AS value, 
+                       rt.response AS otheresponse
+                  FROM {' . static::response_table() . '} r
+             LEFT JOIN {questionnaire_response_other} rt ON rt.choice_id = r.choice_id
+                       AND r.question_id = rt.question_id
+                       AND r.response_id = rt.response_id
+                 WHERE r.response_id = ?';
         $records = $DB->get_records_sql($sql, [$rid]);
         foreach ($records as $record) {
             $answers[$record->questionid][$record->choiceid] = answer\answer::create_from_data($record);
@@ -636,6 +707,9 @@ class rank extends responsetype {
                         if ($contents->modname) {
                             $content = $contents->text;
                         }
+                    }
+                    if (\mod_questionnaire\question\choice::content_other_choice_display($content)) {
+                        $content = \mod_questionnaire\question\choice::content_other_choice_display($content);
                     }
                     if ($osgood) {
                         $choicecol1 = new \stdClass();
@@ -893,17 +967,25 @@ class rank extends responsetype {
                     // Ensure there are two bits of content.
                     list($content, $contentright) = array_merge(preg_split('/[|]/', $content), array(' '));
                     $header = reset($pagetags->totals->headers);
+                    $responsetxt = \mod_questionnaire\question\choice::content_other_choice_display($content);
+                    if (isset($rows[$content]) && $responsetxt) {
+                        $content = $responsetxt . $rows[$content]->content;
+                    }
                     $totalcols[] = (object)['align' => $header->align,
-                        'text' => format_text($content, FORMAT_HTML, ['noclean' => true])];
+                        'text' => format_text($content, FORMAT_HTML, ['noclean' => true, 'filter' => false])];
                 } else {
                     // Eliminate potentially short-named choices.
                     $contents = questionnaire_choice_values($content);
                     if ($contents->modname) {
                         $content = $contents->text;
                     }
+                    $responsetxt = \mod_questionnaire\question\choice::content_other_choice_display($content);
+                    if (isset($rows[$content]) && $responsetxt) {
+                        $content = $responsetxt . $rows[$content]->content;
+                    }
                     $header = reset($pagetags->totals->headers);
                     $totalcols[] = (object)['align' => $header->align,
-                        'text' => format_text($content, FORMAT_HTML, ['noclean' => true])];
+                        'text' => format_text($content, FORMAT_HTML, ['noclean' => true, 'filter' => false])];
                 }
                 // Display ranks/rates numbers.
                 $maxrank = max($rank);

--- a/templates/question_rate.mustache
+++ b/templates/question_rate.mustache
@@ -140,6 +140,7 @@
       <td {{#colstyle}}style="{{.}}"{{/colstyle}}{{#colclass}} class="{{.}}"{{/colclass}}{{#coltitle}} title="{{.}}"{{/coltitle}}
 			{{#colinput}} onclick="if('{{id}}'.length>0) document.getElementById('{{id}}').click()"{{/colinput}}>
         {{#coltext}}{{{.}}}{{/coltext}}
+        {{#oname}}<input size="25" name="{{oname}}" id="{{oid}}" value="" type="text" />{{/oname}}
         {{#colhiddentext}}<span class="accesshide">{{{.}}}</span>{{/colhiddentext}}
         {{#colinput}}<input type="radio" name="{{name}}" id="{{id}}" value="{{value}}"{{#checked}} checked="checked"{{/checked}}{{#disabled}} disabled="disabled"{{/disabled}}{{#onclick}} onclick="{{.}}"{{/onclick}}>
         {{#label}}<label for="{{id}}" class="accesshide">{{{.}}}</label>{{/label}}{{/colinput}}

--- a/templates/response_rate.mustache
+++ b/templates/response_rate.mustache
@@ -70,7 +70,7 @@
     </tr>
     {{#rows}}
     <tr>
-        <td style="text-align:{{textalign}}">{{{content}}}</td>
+        <td style="text-align:{{textalign}}">{{{content}}} {{#othercontent}} <span class="response text">{{.}}</span>{{/othercontent}}</td>
         {{#cols}}
         {{#checked}}
         <td style="text-align:center;" class="selected">

--- a/tests/behat/rate_question_other.feature
+++ b/tests/behat/rate_question_other.feature
@@ -1,0 +1,58 @@
+@mod @mod_questionnaire
+Feature: Rate scale questions have Other option
+  In order to display an Other choice in rate question
+  As a teacher
+  the 'Other' option should display with textbox next to it in the question view
+
+  @javascript
+  Scenario: Create a rate question type with an 'Other' choice and verify the response exists
+    Given the following "users" exist:
+      | username | firstname | lastname | email                |
+      | teacher1 | Teacher   | 1        | teacher1@example.com |
+      | student1 | Student   | 1        | student1@example.com |
+    And the following "courses" exist:
+      | fullname | shortname | category |
+      | Course 1 | C1        | 0        |
+    And the following "course enrolments" exist:
+      | user     | course | role           |
+      | teacher1 | C1     | editingteacher |
+      | student1 | C1     | student        |
+    And the following "activities" exist:
+      | activity      | name               | description                    | course | idnumber       |
+      | questionnaire | Test questionnaire | Test questionnaire description | C1     | questionnaire0 |
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire"
+    And I navigate to "Questions" in current page administration
+    And I add a "Rate (scale 1..5)" question and I fill the form with:
+      | Question Name      | Q1                                                          |
+      | Yes                | y                                                           |
+      | Nb of scale items  | 3                                                           |
+      | Type of rate scale | No duplicate choices                                        |
+      | Question Text      | What are your top three movies?                             |
+      | Possible answers   | Star Wars,Casablanca,Airplane,Citizen Kane,Anchorman,!other |
+    Then I should see "position 1"
+    And I should see "[Rate (scale 1..5)] (Q1)"
+    And I should see "What are your top three movies?"
+    And I log out
+
+    And I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire"
+    And I navigate to "Answer the questions..." in current page administration
+    Then I should see "Test questionnaire"
+    And I should see "What are your top three movies?"
+    And I click on "Row 2, Star Wars: Column 2, 1." "radio"
+    And I click on "Row 4, Airplane: Column 3, 2." "radio"
+    And I click on "Row 3, Casablanca: Column 4, 3." "radio"
+    And I click on "Row 7, !other: Column 4, 3." "radio"
+    And I set the field with xpath "//input[contains(@name,'qother')]" to "Once Upon a Time"
+    And I press "Submit questionnaire"
+    And I press "Continue"
+    Then I should see "Once Upon a Time"
+    And I log out
+    And I log in as "teacher1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire"
+    And I navigate to "View all responses" in current page administration
+    Then I should see "Once Upon a Time(3)"

--- a/tests/behat/rate_question_other.feature
+++ b/tests/behat/rate_question_other.feature
@@ -4,8 +4,7 @@ Feature: Rate scale questions have Other option
   As a teacher
   the 'Other' option should display with textbox next to it in the question view
 
-  @javascript
-  Scenario: Create a rate question type with an 'Other' choice and verify the response exists
+  Background: Create a rate question type with an 'Other' choice
     Given the following "users" exist:
       | username | firstname | lastname | email                |
       | teacher1 | Teacher   | 1        | teacher1@example.com |
@@ -36,6 +35,8 @@ Feature: Rate scale questions have Other option
     And I should see "What are your top three movies?"
     And I log out
 
+  @javascript
+  Scenario: The student inputs text in "Other" and verifies its existence.
     And I log in as "student1"
     And I am on "Course 1" course homepage
     And I follow "Test questionnaire"
@@ -55,4 +56,4 @@ Feature: Rate scale questions have Other option
     And I am on "Course 1" course homepage
     And I follow "Test questionnaire"
     And I navigate to "View all responses" in current page administration
-    Then I should see "Once Upon a Time(3)"
+    Then I should see "Other: Once Upon a Time"


### PR DESCRIPTION
**AC1**: When option 'Other' is added in Scale/Rating question type, the 'Other' option should display with textbox next to it in the question view

**AC2**: When user answer the Scale/Rating question type question with 'Other' responses, it should display the other response as one of the options within the question in:
- Your Response view
- Your Response/Individual responses view
- Your Response/ responses view

**AC3**: When there are multiple responses for that Scale/Rating question: 
In Individual Response view, it will display each individual response per page
In All Response view, it will display each response separately
in the summary view, keep all the input of ‘other’ options as the ‘Other’ category. Therefore it will show as 1 option. 

**AC4**: The other option in Scale/Rating question type should display in Summary view also with the calculation logic: if a user inputs ‘Other’ and ranks it, it should be the rank average of the ‘Other’ category. The calculation for the point and percentage follow the same as existing behaviour (normal option)
Note:
 1. Average rank for each option: sum point of each time rating / total times of rating
 2. Responses point: the percentage of the times option is chosen.