### PR TITLE
Fix description of question_created event

### DIFF
--- a/classes/event/question_created.php
+++ b/classes/event/question_created.php
@@ -48,7 +48,7 @@ class question_created extends \core\event\base {
      */
     public function get_description() {
         $questiontype = $this->other['questiontype'];
-        return "The user with id '$this->userid' has created or modified a question of type '$questiontype' for
-            the questionnaire with course module id '$this->contextinstanceid'.";
+        return "The user with id '$this->userid' has created or modified a question of type '$questiontype' for " .
+            "the questionnaire with course module id '$this->contextinstanceid'.";
     }
 }


### PR DESCRIPTION
The description of the question_created event contained some extra whitespace which was visible in the log report.