### PR TITLE
Fix key calculation

### DIFF
--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -3923,7 +3923,7 @@ class questionnaire {
                 // Just in case a question pertaining to a section has been deleted or made not required
                 // after being included in scorecalculation.
                 if (isset($qscore[$qid])) {
-                    $key = ($key == 0) ? 1 : $key;
+                    $key = empty($key) ? 1 : $key;
                     $score[$section] += round($qscore[$qid] * $key);
                     $maxscore[$section] += round($qmax[$qid] * $key);
                     if ($compare  || $allresponses) {


### PR DESCRIPTION
For unknown reason, $key was an empty string in my moodle instance. (I got questionnaire from moodle 3.11 to 4.3).
To check if $key is null, 0 or empty, I used the function emtpy()