### PR TITLE
Suppres huge size of icons in Manage questions in Moodle 4.5

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -11,6 +11,10 @@
     color: gray;
 }
 
+#page-mod-questionnaire-questions .qcontainer .qnums ~ input[type=image] {
+    max-height: 1em;
+}
+
 #page-mod-questionnaire-questions .qcontainer .fstatic {
     width: 97%;
     margin-right: 1em;


### PR DESCRIPTION
I upgraded my Moodle to 4.5 and found the icons in Manage questions page are super huge. 
It's due to the icons were changed from tiny raster ones to huge SVG ones in 4.5.
We now have to specify their size in CSS.

Fixes #612