### PR TITLE
Save base response when radio button with other is used

### DIFF
--- a/classes/question/question.php
+++ b/classes/question/question.php
@@ -567,6 +567,10 @@ abstract class question {
                 if (!empty($answer->choiceid) && isset($this->choices[$answer->choiceid]) &&
                     $this->choices[$answer->choiceid]->is_other_choice()) {
                     $answered = !empty($answer->value);
+                    $onlyspaces = preg_match("/^[\s]*$/", $answer->value);
+                    if ($onlyspaces) {
+                        $answered = false;
+                    }
                 } else {
                     $answered = (!empty($answer->choiceid) || !empty($answer->value));
                 }

--- a/classes/responsetype/single.php
+++ b/classes/responsetype/single.php
@@ -109,16 +109,15 @@ class single extends responsetype {
             foreach ($response->answers[$this->question->id] as $answer) {
                 if (isset($this->question->choices[$answer->choiceid])) {
                     if ($this->question->choices[$answer->choiceid]->is_other_choice()) {
-                        // If no input specified, ignore this choice.
-                        if (empty($answer->value) || preg_match("/^[\s]*$/", $answer->value)) {
-                            continue;
+                        // If no input specified, don't save other choice, but always save base response.
+                        if (!empty($answer->value) && !preg_match("/^[\s]*$/", $answer->value)) {
+                            $record = new \stdClass();
+                            $record->response_id = $response->id;
+                            $record->question_id = $this->question->id;
+                            $record->choice_id = $answer->choiceid;
+                            $record->response = clean_text($answer->value);
+                            $DB->insert_record('questionnaire_response_other', $record);
                         }
-                        $record = new \stdClass();
-                        $record->response_id = $response->id;
-                        $record->question_id = $this->question->id;
-                        $record->choice_id = $answer->choiceid;
-                        $record->response = clean_text($answer->value);
-                        $DB->insert_record('questionnaire_response_other', $record);
                     }
                     // Record the choice selection.
                     $record = new \stdClass();


### PR DESCRIPTION
This PR fixes should fix 2 things.

1. https://github.com/PoetOS/moodle-mod_questionnaire/commit/05b4ad9045f676a2d02bc0ffc0dd66d023be4fcf

Without this you when you are submitting `other` response containing only spaces no error occurs.
There should be some kind of validation / error when `other` response contains only spaces.

2. https://github.com/PoetOS/moodle-mod_questionnaire/commit/36d16449f0d1d8f9aed507d708811deb18562bdc. 

When submitting question with `other` response there was a `continue` (which applies to foreach / loop) if `$answer->value` was empty or contained only spaces.
It was skipping saving of original base choice. 
So on report page there was no info what user selected / answered.

This commit inverts the logic so base save is always happening.