### PR TITLE
Questionnaire: All branching shown in View your response

### DIFF
--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -423,6 +423,9 @@ class questionnaire {
         }
         $pdf = ($outputtarget == 'pdf') ? true : false;
         foreach ($this->questions as $question) {
+            if (self::is_dependent_on_choices($question, $this->responses[$rid]->answers)) {
+                continue;
+            }
             if ($question->type_id < QUESPAGEBREAK) {
                 $i++;
             }
@@ -4188,5 +4191,27 @@ class questionnaire {
                 WHERE u.id = ?";
         $row = $DB->get_record_sql($sql, array_merge($params, [$userid]));
         return $row;
+    }
+
+    /**
+     * Determines if a question is dependent on another question's choice.
+     *
+     * Checks if the provided question has dependencies on other questions
+     * and if any required answer choices have not been selected.
+     *
+     * @param object $question The question object containing dependencies
+     * @param array $answers   An associative array of answers with question IDs as keys
+     *
+     * @return bool True if the question has an unmet dependency; otherwise, false
+     */
+    public static function is_dependent_on_choices(object $question, array $answers): bool {
+        if (!empty($question->dependencies)) {
+            foreach ($question->dependencies as $dependency) {
+                if (empty($answers[$dependency->dependquestionid][$dependency->dependchoiceid])) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -423,7 +423,8 @@ class questionnaire {
         }
         $pdf = ($outputtarget == 'pdf') ? true : false;
         foreach ($this->questions as $question) {
-            if (self::is_dependent_on_choices($question, $this->responses[$rid]->answers)) {
+            // Only show eligible questions in the response.
+            if (!$question->dependency_fulfilled($rid, $this->questions)) {
                 continue;
             }
             if ($question->type_id < QUESPAGEBREAK) {
@@ -4191,27 +4192,5 @@ class questionnaire {
                 WHERE u.id = ?";
         $row = $DB->get_record_sql($sql, array_merge($params, [$userid]));
         return $row;
-    }
-
-    /**
-     * Determines if a question is dependent on another question's choice.
-     *
-     * Checks if the provided question has dependencies on other questions
-     * and if any required answer choices have not been selected.
-     *
-     * @param object $question The question object containing dependencies
-     * @param array $answers   An associative array of answers with question IDs as keys
-     *
-     * @return bool True if the question has an unmet dependency; otherwise, false
-     */
-    public static function is_dependent_on_choices(object $question, array $answers): bool {
-        if (!empty($question->dependencies)) {
-            foreach ($question->dependencies as $dependency) {
-                if (empty($answers[$dependency->dependquestionid][$dependency->dependchoiceid])) {
-                    return true;
-                }
-            }
-        }
-        return false;
     }
 }

--- a/tests/behat/dependency_question.feature
+++ b/tests/behat/dependency_question.feature
@@ -106,3 +106,21 @@ Feature: Questions can be defined to be dependent on answers to multiple previou
     And I should see "Do you own a dog?"
     And I should see "Parent Question : position 1 (Q1->Dog) set"
     And I log out
+
+  @javascript
+  Scenario: Students can only view answers to questions asked on the individual responses page.
+    Given I log in as "student1"
+    And I am on "Course 1" course homepage
+    And I follow "Test questionnaire"
+    When I navigate to "Answer the questions..." in current page administration
+    And I should see "Do you own a car?"
+    And I click on "Yes" "radio"
+    And I press "Next Page >>"
+    And I should see "What colour is the car?"
+    And I set the field "What colour is the car?" to "Black"
+    And I press "Next Page >>"
+    And I press "Submit questionnaire"
+    And I navigate to "View your response(s)" in current page administration
+    And I should see "Do you own a car?"
+    And I should see "What colour is the car?"
+    Then I should not see "Will you buy a car this year?"


### PR DESCRIPTION
**Context**: Enable the "Allow branching questions" setting. Create a radio question with multiple options, and add corresponding dependency questions for each option. The issue occurs when users answer the question and view their responses.

**Actual Results**: Users can see all of the dependency questions, which can be overwhelming.

**Expected Results**: Users should only see the dependency question that corresponds to the option they selected.

**Impacted Areas**: This fix only impacts the "View your response(s) > Individual responses" page.