### PR TITLE
Add group filter dropdown to List of responses

### DIFF
--- a/report.php
+++ b/report.php
@@ -727,6 +727,13 @@ switch ($action) {
             }
         }
 
+        // Add group filter dropdown.
+        if ($groupmode > 0) {
+            $groupselect = groups_print_activity_menu($cm, $url->out(), true);
+            $questionnaire->page->add_to_page('respondentinfo', $groupselect);
+            $currentgroupid = groups_get_activity_group($cm);
+        }
+    
         if ($byresponse || $rid) {
             // Available group modes (0 = no groups; 1 = separate groups; 2 = visible groups).
             if ($groupmode > 0) {


### PR DESCRIPTION
We've detected that when viewing the _View all responses > Summary_ on a questionnaire with group mode enabled you can filter the group. On the other hand, the _List of responses_ tab doesn't have that option, but the group filter is applied if the user has selected a group on the other tab.

So, this commit adds the group filter to the List of responses tab so that it can be changed directly on that tab.