### PR TITLE
Questionnaire: Make summary page even more intuitive

### DIFF
--- a/lang/en/questionnaire.php
+++ b/lang/en/questionnaire.php
@@ -569,6 +569,7 @@ $string['responsefieldlines'] = 'Input box size';
 $string['responseformat'] = 'Response format';
 $string['responseoptions'] = 'Response options';
 $string['responses'] = 'Responses';
+$string['responses_breakdown'] = '(Submissions: {$a->responses} | In progress: {$a->incomplete})';
 $string['responseview'] = 'Students can view ALL responses';
 $string['responseview_help'] = 'You can specify who can see the responses of all respondents to submitted questionnaires (general statistics tables).';
 $string['responseview_link'] = 'mod/questionnaire/mod#Response_viewing';

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -2887,6 +2887,23 @@ class questionnaire {
             if ($userview === 'y') {
                 $respondentstring = get_string('submissions', 'questionnaire');
             }
+            if (!$userview) {
+                $completedcount = 0;
+                $inprogresscount = 0;
+
+                foreach ($rows as $row) {
+                    if ($row->complete === 'y') {
+                        $completedcount++;
+                    } else if ($row->complete === 'n') {
+                        $inprogresscount++;
+                    }
+                }
+                $numresps .= ' ' . get_string('responses_breakdown', 'questionnaire',
+                    [
+                        'responses' => $completedcount,
+                        'incomplete' => $inprogresscount,
+                    ]);
+            }
             $this->page->add_to_page('respondentinfo',
                     ' ' . $respondentstring . ': <strong>' . $numresps . '</strong>');
             if (empty($rows)) {

--- a/tests/behat/check_responses.feature
+++ b/tests/behat/check_responses.feature
@@ -35,7 +35,7 @@ Feature: Review responses
     Then I should see "View all responses"
     And I navigate to "View all responses" in current page administration
     And I should see "View Default order"
-    And I should see "Responses: 7"
+    And I should see "Responses: 7 (Submissions: 6 | In progress: 1)"
     And I set the field "View" to "Full submissions"
     And I should see "Submissions: 6"
     And I set the field "View" to "Responses not submitted"
@@ -70,7 +70,7 @@ Feature: Review responses
     Then I should see "1 / 6"
     And I follow "Summary"
     And I should see "View Default order"
-    And I should see "Responses: 6"
+    And I should see "Responses: 6 (Submissions: 6 | In progress: 0)"
     And I follow "Delete ALL Responses"
     Then I should see "Are you sure you want to delete ALL the responses in this questionnaire?"
     And I press "Delete"

--- a/tests/behat/check_responses_capabilities.feature
+++ b/tests/behat/check_responses_capabilities.feature
@@ -33,7 +33,7 @@ Feature: Review responses with different capabilities
     And I navigate to "View all responses" in current page administration
     Then I should see "All responses"
     And I should see "View Default order"
-    And I should see "Responses: 7"
+    And I should see "Responses: 7 (Submissions: 6 | In progress: 1)"
     And I log out
 
   @javascript


### PR DESCRIPTION
Currently, when users click "View all responses" in the questionnaire module, they see a total count of responses but cannot distinguish between completed submissions and incomplete (in-progress) responses. This makes it difficult for instructors to understand the actual status of their questionnaire data at a glance.
**Current Behavior**
The interface displays only:
<img width="1078" height="733" alt="image" src="https://github.com/user-attachments/assets/6b00f090-b242-4f1a-8d2f-bbeccf02d07b" />
**Proposed Solution**
Add a detailed breakdown that shows both completed and incomplete responses:
<img width="1207" height="706" alt="image" src="https://github.com/user-attachments/assets/65deeca0-ed83-4dea-8e95-c4794bd8a9c8" />
**Benefits**

- Improved clarity: Users can immediately see how many responses are actually completed
- Better data insight: Instructors can track participation and completion rates
- Enhanced user experience: More informative interface without cluttering the UI

This change provides essential information that helps users better understand their questionnaire response data and make informed decisions about when to close a questionnaire or follow up with participants.
FYI: @mchurchward 
