### PR TITLE
Fix numerical response value

### DIFF
--- a/classes/responsetype/numericaltext.php
+++ b/classes/responsetype/numericaltext.php
@@ -34,7 +34,8 @@ class numericaltext extends text {
      */
     public static function answers_from_webform($responsedata, $question) {
         $answers = [];
-        if (isset($responsedata->{'q'.$question->id}) && is_numeric($responsedata->{'q'.$question->id})) {
+        // Do not check with is_numeric, all the characters replacing needs to be done for non-numeric
+        if (isset($responsedata->{'q'.$question->id})) {
             $val = $responsedata->{'q' . $question->id};
             // Allow commas as well as points in decimal numbers.
             $val = str_replace(",", ".", $responsedata->{'q' . $question->id});

--- a/classes/responsetype/numericaltext.php
+++ b/classes/responsetype/numericaltext.php
@@ -34,7 +34,7 @@ class numericaltext extends text {
      */
     public static function answers_from_webform($responsedata, $question) {
         $answers = [];
-        // Do not check with is_numeric, all the characters replacing needs to be done for non-numeric
+        // Do not check with is_numeric, all the characters replacing needs to be done for non-numeric.
         if (isset($responsedata->{'q'.$question->id})) {
             $val = $responsedata->{'q' . $question->id};
             // Allow commas as well as points in decimal numbers.


### PR DESCRIPTION
Removed the [is_numeric()](https://www.php.net/manual/en/function.is-numeric.php) check since the preg_replace() function already handles the extraction of valid numeric values. This fix properly processes inputs with comma decimal separators and maintains the intended behavior while simplifying the code.

The original code did not handle non-standard numeric values correctly, e.g. using comma as decimal separator (42,6).