### PR TITLE
fix(db): Make sql statement compatible to Microsoft SQL Server

### DIFF
--- a/classes/responsetype/rank.php
+++ b/classes/responsetype/rank.php
@@ -317,8 +317,8 @@ class rank extends responsetype {
                   WHERE c.question_id = ?
                         AND c.content = '!other'
                         AND ro.response <> ''
-               GROUP BY ro.response, cid
-               ORDER BY cid";
+               GROUP BY ro.response, c.id
+               ORDER BY c.id";
         return $DB->get_records_sql($osql, array_merge($params, [$this->question->id]));
     }
 


### PR DESCRIPTION
... while not breaking others ...

We are running Moodle with Microsoft's SQL Server (don't judge me :-) and are facing dialect issues with T-SQL. Here I provide a fix that does not use column aliases in `GROUP|ORDER BY` clauses, because T-SQL does not understand them.

Otherwise the error on our side looks like the following:

```
Debug info: SQLState: 42S22<br>
Error Code: 207<br>
Message: [Microsoft][ODBC Driver 17 for SQL Server][SQL Server]Invalid column name 'cid'.<br>

SELECT ro.response, AVG(a.rankvalue) AS average, COUNT(a.response_id) AS num, c.id as cid
FROM mdl_questionnaire_quest_choice c
INNER JOIN mdl_questionnaire_response_rank a ON a.choice_id = c.id
AND a.rankvalue >= 0
AND a.question_id = c.question_id AND response_id IN ('369054','369104','369105')
INNER JOIN mdl_questionnaire_response_other ro ON ro.choice_id = c.id
AND ro.response_id = a.response_id
AND ro.question_id = c.question_id
WHERE c.question_id = '115862'
AND c.content = '!other'
AND ro.response <> ''
GROUP BY ro.response, cid
ORDER BY cid
[array (
0 => '369054',
1 => '369104',
2 => '369105',
3 => '115862',
)]
Error code: dmlreadexception Stack trace:

    line 497 of /lib/dml/moodle_database.php: dml_read_exception thrown
    line 331 of /lib/dml/sqlsrv_native_moodle_database.php: call to moodle_database->query_end()
    line 438 of /lib/dml/sqlsrv_native_moodle_database.php: call to sqlsrv_native_moodle_database->query_end()
    line 909 of /lib/dml/sqlsrv_native_moodle_database.php: call to sqlsrv_native_moodle_database->do_query()
    line 985 of /lib/dml/sqlsrv_native_moodle_database.php: call to sqlsrv_native_moodle_database->get_recordset_sql()
    line 314 of /mod/questionnaire/classes/responsetype/rank.php: call to sqlsrv_native_moodle_database->get_records_sql()
    line 165 of /mod/questionnaire/classes/responsetype/rank.php: call to mod_questionnaire\responsetype\rank->get_other_choice()
    line 387 of /mod/questionnaire/classes/responsetype/rank.php: call to mod_questionnaire\responsetype\rank->get_results()
    line 447 of /mod/questionnaire/classes/question/question.php: call to mod_questionnaire\responsetype\rank->display_results()
    line 328 of /mod/questionnaire/classes/output/renderer.php: call to mod_questionnaire\question\question->display_results()
    line 2957 of /mod/questionnaire/questionnaire.class.php: call to mod_questionnaire\output\renderer->results_output()
    line 688 of /mod/questionnaire/report.php: call to questionnaire->survey_results()
```