### PR TITLE
Detect button::BODY_OUTLINE reliably.

### DIFF
--- a/classes/courseformat/overview.php
+++ b/classes/courseformat/overview.php
@@ -91,10 +91,20 @@ class overview extends \core_courseformat\activityoverviewbase {
 
         $currentanswerscount = $this->manager->count_all_users_answered();
 
+        if (
+            class_exists(button::class) &&
+            (new \ReflectionClass(button::class))->hasConstant('BODY_OUTLINE')
+        ) {
+            $bodyoutline = button::BODY_OUTLINE;
+            $buttonclass = $bodyoutline->classes();
+        } else {
+            $buttonclass = "btn btn-outline-secondary";
+        }
+
         $content = new action_link(
             url: new \moodle_url('/mod/questionnaire/report.php', ['instance' => $this->cm->instance]),
             text: get_string('view', 'core'),
-            attributes: ['class' => button::SECONDARY_OUTLINE->classes()],
+            attributes: ['class' => $buttonclass],
         );
 
         return new overviewitem(

--- a/tests/behat/overview_report.feature
+++ b/tests/behat/overview_report.feature
@@ -165,10 +165,7 @@ Feature: Testing overview integration in mod_questionnaire
     And I should not see "Responded" in the "questionnaire_overview_collapsible" "region"
 
   Scenario: The questionnaire index redirect to the activities overview
-    When I log in as "admin"
-    And I am on "Course 1" course homepage with editing mode on
-    And I add the "Activities" block
-    And I click on "Questionnaires" "link" in the "Activities" "block"
+    When I am on the "C1" "course > activities > questionnaire" page logged in as "admin"
     Then I should see "An overview of all activities in the course"
     And I should see "Name" in the "questionnaire_overview_collapsible" "region"
     And I should see "Due date" in the "questionnaire_overview_collapsible" "region"


### PR DESCRIPTION
The class of the activity overview page should be of class button::BODY_OUTLINE where it exists (Moodle ≥ 5.1) and of btn btn-outline-secondary (corrisponding to button::BODY_SECONDARY) where it does not exist (Moodle ≤ 5.0).

Additionally, @mchurchward, this lets the tests for Moodle 5.2 (main) pass.
The "Activities" block has been removed in the next (to be released 20th of April) Moodle version.

Thanks!