### PR TITLE
Incomplete responses show -999 on downloaded report OU 980876

### DIFF
--- a/classes/question/question.php
+++ b/classes/question/question.php
@@ -46,6 +46,7 @@ define('QUESSLIDER', 11);
 define('QUESFILE', 12);
 define('QUESPAGEBREAK', 99);
 define('QUESSECTIONTEXT', 100);
+define('QUESRATEUNANSWERED', -999);
 
 global $idcounter, $CFG;
 $idcounter = 0;

--- a/classes/question/rate.php
+++ b/classes/question/rate.php
@@ -315,7 +315,8 @@ class rate extends question {
 
         $num = 0;
         foreach ($this->choices as $cid => $choice) {
-            $num += (isset($response->answers[$this->id][$cid]) && ($response->answers[$this->id][$cid]->value != -999));
+            $num += (isset($response->answers[$this->id][$cid]) &&
+                $response->answers[$this->id][$cid]->value != QUESRATEUNANSWERED);
         }
 
         $notcomplete = false;
@@ -361,13 +362,13 @@ class rate extends question {
                     $title = '';
                     if (
                         $notcomplete && isset($response->answers[$this->id][$cid]) &&
-                        ($response->answers[$this->id][$cid]->value == -999)
+                        $response->answers[$this->id][$cid]->value == QUESRATEUNANSWERED
                     ) {
                         $completeclass = 'notcompleted';
                         $title = get_string('pleasecomplete', 'questionnaire');
                     }
-                    // Set value of notanswered button to -999 in order to eliminate it from form submit later on.
-                    $colinput = ['name' => $str, 'value' => -999];
+                    // Set value of notanswered button in order to eliminate it from form submit later on.
+                    $colinput = ['name' => $str, 'value' => QUESRATEUNANSWERED];
                     if (!empty($checked)) {
                         $colinput['checked'] = true;
                     }
@@ -624,8 +625,8 @@ class rate extends question {
                 if (isset($answers[$cid]) && !empty($answers[$cid]) && ($answers[$cid]->value == $na)) {
                     $answers[$cid]->value = -1;
                 }
-                // If choice value == -999 this is a not yet answered choice.
-                $num += (isset($answers[$cid]) && ($answers[$cid]->value != -999));
+                // Ignore if value means this is a not yet answered choice.
+                $num += (isset($answers[$cid]) && $answers[$cid]->value != QUESRATEUNANSWERED);
             }
             $nbchoices -= $nameddegrees;
         }
@@ -675,8 +676,8 @@ class rate extends question {
                 if (isset($answers[$cid]) && ($answers[$cid]->value == $na)) {
                     $answers[$cid]->value = -1;
                 }
-                // If choice value == -999 this is a not yet answered choice.
-                $num += (isset($answers[$cid]) && ($answers[$cid]->value != -999));
+                // Ignore if value means this is a not yet answered choice.
+                $num += (isset($answers[$cid]) && $answers[$cid]->value != QUESRATEUNANSWERED);
             }
             $nbchoices -= $nameddegrees;
         }

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -2450,7 +2450,8 @@ class questionnaire {
                             } else {
                                 $rating = $this->responses[$rid]->answers[$question->id][$cid]->value;
                             }
-                            $response->answers[] = $question->choices[$cid]->content . ' = ' . $rating;
+                            $response->answers[] = $question->choices[$cid]->content . ' = ' .
+                                ($rating != QUESRATEUNANSWERED ? $rating : '');
                         }
                     }
                 }
@@ -3473,7 +3474,8 @@ class questionnaire {
 
         for ($c = $nbinfocols; $c < $numrespcols; $c++) {
             if (isset($row[$c])) {
-                $positioned[] = $row[$c];
+                // Ignore if value means this is a not yet answered choice.
+                $positioned[] = $row[$c] != QUESRATEUNANSWERED ? $row[$c] : null;
             } else if (isset($questionsbyposition[$c])) {
                 $question = $questionsbyposition[$c];
                 $qtype = intval($question->type_id);

--- a/tests/behat/behat_mod_questionnaire.php
+++ b/tests/behat/behat_mod_questionnaire.php
@@ -448,11 +448,11 @@ class behat_mod_questionnaire extends behat_base {
             ["", "6", "13", "18", "-1"],
             ["", "6", "13", "19", "1"],
             ["", "6", "13", "20", "-1"],
-            ["", "7", "13", "16", "-999"],
-            ["", "7", "13", "17", "-999"],
-            ["", "7", "13", "18", "-999"],
-            ["", "7", "13", "19", "-999"],
-            ["", "7", "13", "20", "-999"],
+            ["", "7", "13", "16", QUESRATEUNANSWERED],
+            ["", "7", "13", "17", QUESRATEUNANSWERED],
+            ["", "7", "13", "18", QUESRATEUNANSWERED],
+            ["", "7", "13", "19", QUESRATEUNANSWERED],
+            ["", "7", "13", "20", QUESRATEUNANSWERED],
         ];
         $this->add_data(
             $responserank,

--- a/tests/csvexport_test.php
+++ b/tests/csvexport_test.php
@@ -76,17 +76,19 @@ final class csvexport_test extends \advanced_testcase {
             $questionnaireinst = new \questionnaire($course, $cm, 0, $questionnaire);
 
             // Test for only complete responses.
+            $expectedoutput = $this->expected_complete_output();
             $newoutput = $this->get_csv_text($questionnaireinst->generate_csv(0, '', '', 0, 0, 0));
-            $this->assertEquals(count($newoutput), count($this->expected_complete_output()));
+            $this->assertEquals(count($newoutput), count($expectedoutput));
             foreach ($newoutput as $key => $output) {
-                $this->assertEquals($this->expected_complete_output()[$key], $output);
+                $this->assertEquals($expectedoutput[$key], $output, "Output #$key");
             }
 
             // Test for all responses.
+            $expectedoutput = $this->expected_incomplete_output();
             $newoutput = $this->get_csv_text($questionnaireinst->generate_csv(0, '', '', 0, 0, 1));
-            $this->assertEquals(count($newoutput), count($this->expected_incomplete_output()));
+            $this->assertEquals(count($newoutput), count($expectedoutput));
             foreach ($newoutput as $key => $output) {
-                $this->assertEquals($this->expected_incomplete_output()[$key], $output);
+                $this->assertEquals($expectedoutput[$key], $output, "Output #$key");
             }
         }
     }
@@ -243,6 +245,6 @@ final class csvexport_test extends \advanced_testcase {
             "		Test course 1			Testy Lastname4	username4	y	Test answer	Some header textSome paragraph text	83	" .
             "27/12/2017	wind	three	0	0	0	0	0	0	0	0	0	1	1	2	3	4	5	1	2	3	4		5",
             "		Test course 1			Testy Lastname5	username5	n	Test answer	Some header textSome paragraph text	83	" .
-            "27/12/2017	wind	three	0	0	0	0	0	0	0	0	0	1	1	2	3	4	5	1	2	3	4		5"];
+            "27/12/2017	wind	three	0	0	0	0	0	0	0	0	0	1											5"];
     }
 }

--- a/tests/generator/lib.php
+++ b/tests/generator/lib.php
@@ -661,7 +661,8 @@ class mod_questionnaire_generator extends testing_module_generator {
                 case QUESRATE:
                     $answers = [];
                     for ($a = 0; $a < count($choices) - 1; $a++) {
-                        $answers[] = new question_response_rank($choices[$a], (($a % 5) + 1));
+                        $rank = $complete ? (($a % 5) + 1) : QUESRATEUNANSWERED;
+                        $answers[] = new question_response_rank($choices[$a], $rank);
                     }
                     $responses[] = new question_response($question->id, $answers);
                     break;

--- a/tests/privacy_provider_test.php
+++ b/tests/privacy_provider_test.php
@@ -138,8 +138,8 @@ final class privacy_provider_test extends \core_privacy\tests\provider_testcase 
         $this->assertEquals('7. Numeric 1004', $data->responses[0]['questions'][7]->questionname);
         $this->assertEquals(83, $data->responses[0]['questions'][7]->answers[0]);
         $this->assertEquals('22. Rate Scale 1014', $data->responses[0]['questions'][22]->questionname);
-        $this->assertEquals('fourteen = 1', $data->responses[0]['questions'][22]->answers[0]);
-        $this->assertEquals('happy = 3', $data->responses[0]['questions'][22]->answers[7]);
+        $this->assertEquals('fourteen = ', $data->responses[0]['questions'][22]->answers[0]);
+        $this->assertEquals('happy = ', $data->responses[0]['questions'][22]->answers[7]);
     }
 
     /**


### PR DESCRIPTION
In a questionnaire with incomplete scale/rate responses a downloaded report shows -999 which is an internal value used to indicate unanswered questions.

To reproduce:
- Select View all responses.
- On the next page, select Download from the View all responses dropdown. 
- Check the Include incomplete responses checkbox option.
- Click download.
- The data contains -999 values for the incomplete scale/rate responses.
