### PR TITLE
View your responses title doesn't fit when displayed in chart OU 975833

### DIFF
--- a/drawchart.php
+++ b/drawchart.php
@@ -55,8 +55,8 @@ function draw_chart(
     }
     $nblabels = count($labels);
     $charttitlefont = "Verdana";
-    $charttitlesize = 10;
-    $charttitlesize2 = 10;
+    $charttitlesize = 9;
+    $charttitlesize2 = 9;
     if ($PAGE->pagetype == 'mod-questionnaire-myreport') {
         $charttitle = get_string('yourresponse', 'questionnaire');
     } else {


### PR DESCRIPTION
To reproduce:
- Setup a questionnaire with Global Feedback and Chart type - Vertical Progress bar.
- Answer the questoins.
- View your responses - Individual responses.
The title above the chart doesn't fit and shows as "iew your responses".
