### PR TITLE
Cache completion state to eliminate redundant DB queries

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,30 @@
 Release Notes
 
+Release 4.4.0.02 (Feature/completion-cache)
+
+Performance:
+* Added completion state caching to eliminate redundant DB queries during grade
+  recalculation and completion reports.
+
+Problem:
+* The function `questionnaire_get_completion_state()` executed 2 DB queries per check (load questionnaire record + check response existence). During grade recalculation, this is called for every student on every activity that has an availability condition based on questionnaire completion. On a course with 500 students and 45 dependent activities, this produced ~46,000 queries per regrade.
+  At 100,000 users this would reach ~9,000,000 queries.
+
+Solution:
+* [SPECAPPS-205] New class `\mod_questionnaire\completion_cache` provides two layers of caching:
+  - Questionnaire record cache: loads each questionnaire's settings once per request, eliminating repeated identical queries across users.
+  - Lazy bulk preload: on first completion check for a questionnaire, loads ALL completed user IDs in a single `SELECT DISTINCT userid` query. All subsequent checks for any user on the same questionnaire are PHP array lookups with zero DB queries.
+
+Cache invalidation:
+* Cache is invalidated on response submit (both initial and resume paths) and response delete, ensuring correctness when completion state changes mid-request.
+
+Files changed:
+* classes/completion_cache.php (new) - cache class with check(), clear(), invalidate() methods
+* lib.php - questionnaire_get_completion_state() delegates to cache
+* questionnaire.class.php - cache invalidation on submit
+* locallib.php - cache invalidation on delete
+* tests/custom_completion_test.php - setUp() added to clear cache between tests
+
 Release 4.4.0 (Build - 2025110900)
 New Features:
 * [PR590](https://github.com/PoetOS/moodle-mod_questionnaire/pull/590): Allow responses to be deleted automatically after a specified time. This is disabled by default.

--- a/classes/completion_cache.php
+++ b/classes/completion_cache.php
@@ -1,0 +1,101 @@
+<?php
+// This file is part of Moodle - http://moodle.org/
+//
+// Moodle is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Moodle is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Moodle.  If not, see <http://www.gnu.org/licenses/>.
+
+namespace mod_questionnaire;
+
+/**
+ * Caches questionnaire completion state to avoid repeated DB queries.
+ *
+ * On first check for a questionnaire, bulk-loads all completed user IDs
+ * for that questionnaire into memory. Subsequent checks for any user on
+ * the same questionnaire are served from the cache with zero DB queries.
+ *
+ * Also caches questionnaire records so the same instance isn't loaded
+ * repeatedly across different users.
+ *
+ * @package    mod_questionnaire
+ * @copyright  2026 Jamie Burgess, NSW Department of Education
+ * @license    http://www.gnu.org/copyleft/gpl.html GNU GPL v3 or later
+ */
+class completion_cache {
+
+    /** @var array Questionnaire records keyed by instance ID. */
+    private static $questionnaires = [];
+
+    /** @var array Completed user sets keyed by questionnaire ID. Each value is userid => true. */
+    private static $completed = [];
+
+    /**
+     * Check whether a user has completed a questionnaire.
+     *
+     * @param \stdClass $cm Course module object.
+     * @param int $userid User ID to check.
+     * @param mixed $type Completion type (returned if completionsubmit is disabled).
+     * @return bool|mixed True if completed, false if not, $type if completion not enabled.
+     */
+    public static function check($cm, int $userid, $type) {
+        global $DB;
+
+        $instanceid = $cm->instance;
+
+        // Load questionnaire record from cache or DB.
+        if (!isset(self::$questionnaires[$instanceid])) {
+            self::$questionnaires[$instanceid] = $DB->get_record('questionnaire',
+                ['id' => $instanceid], '*', MUST_EXIST);
+        }
+        $questionnaire = self::$questionnaires[$instanceid];
+
+        if (!$questionnaire->completionsubmit) {
+            return $type;
+        }
+
+        $qid = $questionnaire->id;
+
+        // Lazy bulk preload: on first check for this questionnaire,
+        // load ALL completed user IDs in a single query.
+        if (!isset(self::$completed[$qid])) {
+            self::$completed[$qid] = [];
+            $records = $DB->get_records_sql(
+                'SELECT DISTINCT userid FROM {questionnaire_response} WHERE questionnaireid = ? AND complete = ?',
+                [$qid, 'y']);
+            foreach ($records as $record) {
+                self::$completed[$qid][$record->userid] = true;
+            }
+        }
+
+        return isset(self::$completed[$qid][$userid]);
+    }
+
+    /**
+     * Clear all caches.
+     *
+     * Call after any operation that changes questionnaire responses
+     * (submit, delete) within the same request.
+     */
+    public static function clear(): void {
+        self::$questionnaires = [];
+        self::$completed = [];
+    }
+
+    /**
+     * Invalidate the completion cache for a specific questionnaire.
+     *
+     * @param int $questionnaireid The questionnaire ID to invalidate.
+     */
+    public static function invalidate(int $questionnaireid): void {
+        unset(self::$completed[$questionnaireid]);
+    }
+}

--- a/lib.php
+++ b/lib.php
@@ -1232,19 +1232,7 @@ function questionnaire_reset_userdata($data) {
  *
  */
 function questionnaire_get_completion_state($cm, $userid, $type) {
-    global $DB;
-
-    // Get questionnaire details.
-    $questionnaire = $DB->get_record('questionnaire', array('id' => $cm->instance), '*', MUST_EXIST);
-
-    // If completion option is enabled, evaluate it and return true/false.
-    if ($questionnaire->completionsubmit) {
-        $params = ['userid' => $userid, 'questionnaireid' => $questionnaire->id, 'complete' => 'y'];
-        return $DB->record_exists('questionnaire_response', $params);
-    } else {
-        // Completion option is not enabled so just return $type.
-        return $type;
-    }
+    return \mod_questionnaire\completion_cache::check($cm, $userid, $type);
 }
 
 /**

--- a/locallib.php
+++ b/locallib.php
@@ -403,6 +403,9 @@ function questionnaire_delete_response($response, $questionnaire='') {
     $status = $status && $DB->delete_records('questionnaire_response', array('id' => $rid));
 
     if ($status && $cm) {
+        // Invalidate completion cache after response deletion.
+        \mod_questionnaire\completion_cache::invalidate($questionnaire->id);
+
         // Update completion state if necessary.
         $completion = new completion_info($questionnaire->course);
         if ($completion->is_enabled($cm) == COMPLETION_TRACKING_AUTOMATIC && $questionnaire->completionsubmit) {

--- a/questionnaire.class.php
+++ b/questionnaire.class.php
@@ -321,6 +321,9 @@ class questionnaire {
 
                 $this->update_grades($quser);
 
+                // Invalidate completion cache before updating state.
+                \mod_questionnaire\completion_cache::invalidate($this->id);
+
                 // Update completion state.
                 $completion = new completion_info($this->course);
                 if ($completion->is_enabled($this->cm) && $this->completionsubmit) {
@@ -375,6 +378,9 @@ class questionnaire {
         }
 
         $this->update_grades($quser);
+
+        // Invalidate completion cache before updating state.
+        \mod_questionnaire\completion_cache::invalidate($this->id);
 
         // Update completion state.
         $completion = new \completion_info($this->course);

--- a/tests/custom_completion_test.php
+++ b/tests/custom_completion_test.php
@@ -47,6 +47,14 @@ require_once($CFG->dirroot . '/mod/questionnaire/classes/question/question.php')
 class custom_completion_test extends \advanced_testcase {
 
     /**
+     * Clear completion cache between tests.
+     */
+    public function setUp(): void {
+        parent::setUp();
+        \mod_questionnaire\completion_cache::clear();
+    }
+
+    /**
      * Data provider for get_state().
      *
      * @return array[]

--- a/version.php
+++ b/version.php
@@ -25,10 +25,10 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version = 2024080100.01;  // The current module version (Date: YYYYMMDDXX).
+$plugin->version = 2024080100.02;  // The current module version (Date: YYYYMMDDXX).
 $plugin->requires = 2024042200.00; // Moodle version (4.4.0).
 
 $plugin->component = 'mod_questionnaire';
 
-$plugin->release = '4.4.0 (Build - 2025110900)';
+$plugin->release = '4.4.0.02 (Feature/completion-cache)';
 $plugin->maturity = MATURITY_STABLE;


### PR DESCRIPTION
# Completion State Caching for mod\_questionnaire

## Summary

Adding a static in-memory cache for questionnaire completion state checks, eliminates redundant database queries during grade recalculation and completion report generation.

## Perfomance Issue at scale

The function `questionnaire_get_completion_state()` is called every time Moodle needs to check whether a user has completed a questionnaire. Each call executes **2 DB queries**:

1. `get_record('questionnaire', ...)` - loads the questionnaire settings
2. `record_exists('questionnaire_response', ...)` — checks if the user has a completed response

This is fine for a single check, but becomes a bottleneck in bulk operations:

- **Grade recalculation**: When grade items are marked as needing update, Moodle recalculates grades for every student. Activities with availability conditions based on questionnaire completion trigger a completion check for each student per dependent activity — common in courses that gate later content on a pre-survey or consent questionnaire.

- **Completion reports**: Progress reports and course completion reports evaluate completion for all students across all activities.

### Real-world impact (measured on test data)

The figures below are from a course that uses questionnaire completion as an availability restriction extensively (e.g. a consent/intake questionnaire gating most subsequent activities). The cost scales as 'students × gated activities × 2 queries', so sites with lighter use of questionnaire-based gating will see the same percentage reduction (just at smaller scale).

| Scenario      | Students | Dependent activities | DB queries (before) | DB queries (after) |
| ------------- | -------- | -------------------- | ------------------- | ------------------ |
| Grade regrade | 510      | 45                   | **46,260**          | **40**             |
| Grade regrade | 100,000  | 45                   | **~9,000,000**      | **40**             |

### Benchmark results

| Metric                       | Before | After | Improvement           |
| ------------------- | -------| ----- | -------------------  |
| DB reads (regrade) | 7,196  | 278   | **96.1% reduction** |
| Time (regrade).       | 0.98s  | 0.13s | **86.3% faster**     |

## Solution

This PR adds `\mod_questionnaire\completion_cache` — a static in-memory cache with two layers:

### 1. Questionnaire record cache

Caches the questionnaire DB record by instance ID. Since the 'completionsubmit' setting is the same for all users in a questionnaire, this eliminates repeated identical queries.

### 2. Lazy bulk preload of completion status

On the first completion check for a given questionnaire, executes a single query:

```sql
SELECT DISTINCT userid FROM {questionnaire_response}
WHERE questionnaireid = ? AND complete = 'y'
```

This loads **all** completed user IDs for that questionnaire into a PHP array. All subsequent checks for any user on the same questionnaire are simple `isset()` lookups — zero DB queries.

### Memory usage

Below are sample measurements of memory usage at scale:
- Each completed user ID in the cache uses \~64 bytes
- 100,000 completed users = \~6.4 MB per questionnaire
- 20 questionnaires in a course = \~128 MB worst case
- Cache is freed at end of each HTTP request

## Cache invalidation

The cache is invalidated at all points where questionnaire response data changes:

| Location                               | Event                        | Method                              |
| -------------------------------------- | ---------------------------- | ----------------------------------- |
| `questionnaire.class.php` (line \~324) | Response submitted (initial) | `completion_cache::invalidate($id)` |
| `questionnaire.class.php` (line \~382) | Response submitted (resume)  | `completion_cache::invalidate($id)` |
| `locallib.php` (line \~407)            | Response deleted             | `completion_cache::invalidate($id)` |

The `invalidate()` method removes only the specific questionnaire's cache, not all cached data.

A full `clear()` method is also available for use in testing or maintenance contexts.

## Safety analysis

### Stale cache risk

| Scenario                 | Risk                                                                                                 | Assessment                                             |
| ------------------------ | -----------------------------------------------------------------------------------------------------| ------------------------------------------------------ |
| Student submits response | Submit path calls `update_state(COMPLETION_COMPLETE)` which writes directly, bypassing `get_state()` | **Safe** — cache is invalidated before `update_state`  |
| Response deleted         | Delete path calls `update_state(COMPLETION_INCOMPLETE)`                                              | **Safe** — cache is invalidated before `update_state`  |
| Bulk report (many users) | Each user checked once                                                                               | **Target use case** — one query replaces thousands.    |
| Course page (one user)   | Moodle's own `completion_info` cache handles per-user caching                                        | **Safe** — our cache adds minimal overhead             |
| Availability conditions  | Moodle reads completion via `completion_info::get_data()` which may call `get_state()`               | **Safe** — tested with chained availability conditions |

### PHPUnit considerations

Static caches persist across test methods within a single test class. A `setUp()` method was added to `custom_completion_test` to clear the cache between tests, preventing cross-test contamination.

## Files changed

| File                               | Change                                                                          |
| ---------------------------------- | ------------------------------------------------------------------------------- |
| `classes/completion_cache.php`     | **New** — cache class with `check()`, `clear()`, `invalidate()` methods         |
| `lib.php`                          | `questionnaire_get_completion_state()` delegates to `completion_cache::check()` |
| `questionnaire.class.php`          | Cache invalidation added at both response submit paths                          |
| `locallib.php`                     | Cache invalidation added at response delete path                                |
| `tests/custom_completion_test.php` | `setUp()` added to clear cache between tests                                    |

## Testing

- All **53 existing PHPUnit tests pass** (398 assertions)
- Completion state verified against direct DB queries for correctness
- Availability condition chains tested (questionnaire completion gates assignment access)
- Cache hit/miss behaviour verified (first call = 2 DB reads, subsequent = 0)

## How to verify

### Functional testing (UI)

1. **Setup**: Use a course that has questionnaires with completion tracking enabled ("Student must submit this questionnaire to complete it") and other activities that require questionnaire completion as an access restriction.

2. **Test completion still works**:
   - Log in as a student
   - Submit a questionnaire that gates other activities
   - Verify the dependent activities become available after submission
   - Check the activity completion tick appears on the course page

3. **Test completion reports**:
   - Log in as a teacher/admin
   - Navigate to **Course > Reports > Activity completion**
   - Verify questionnaire completion states display correctly for all students
   - Navigate to **Course > Reports > Course completion** and verify it loads without errors

4. **Test grade regrade**:
   - As an admin, grade an assignment in the course
   - Navigate to the course gradebook
   - Verify it loads without errors and grade totals are correct
   - Check that the gradebook page loads in a reasonable time (should be noticeably faster than before on courses with many students and questionnaire-based restrictions)

5. **Test response deletion**:
   - As a teacher, delete a student's questionnaire response
   - Verify the student's completion state updates (tick removed from course page)
   - Verify the dependent activities become restricted again for that student

### Performance testing (optional, requires admin access)

This test measures the reduction in database queries. You will need a course with 100+ enrolled students, questionnaires with completion enabled, and activities restricted by questionnaire completion.

1. **Setup**
   - Use a course that has questionnaires with completion tracking enabled ("Student must submit this questionnaire to complete it") and other activities that require questionnaire completion as an access restriction.
   - Ideally, this course should have hundreds of users with hundreds of assignments with submissions.

2. **Enable the Excimer profiler for a specific page**:
   - Ensure the Excimer profiler plugin is installed (**Site admin > Plugins > Admin tools > Excimer profiler**)
   - Append `&FLAMEME=1` to the URL of the page you want to profile (e.g. the gradebook or activity completion report)
   - This captures a profile for that single page load

3. **Trigger a grade recalculation**:
   - Set all grade items to require a regrade using a query like the below:
     UPDATE mdl_grade_items SET needsupdate = 1 WHERE courseid = 123;
   - Navigate to the course gradebook or the assign/grader page — this triggers a regrade for any stale grade items

4. **View the profiler results**:
   - Go to **Site admin > Plugins > Admin tools > Excimer profiler > Slowest web requests**
   - Find the gradebook page load or the assign/grader page
   - Click into the profile to see the **DB reads** count

5. **Compare before and after**:
   - On the branch **without** this change, a course with 500 students and 45 questionnaire-dependent activities will show approximately **46,000+ DB reads** during a full regrade
   - On the branch **with** this change, the same operation should show approximately **300 DB reads** or fewer
   - The page load time should also be significantly faster (measured at 86% faster in benchmarks)

6. **Alternative — use Moodle debug footer**:
   - If Excimer is not available, enable **Site admin > Development > Debugging > Performance info** (`$CFG->perfdebug = 15`)
   - The page footer will show total DB reads for each page load
   - Compare the DB reads on the gradebook or activity completion report page before and after the change

@mchurchward, is this something you can review? Thank you!